### PR TITLE
[CLEANUP] fix import for ActionRunnerTest.java

### DIFF
--- a/core/src/test/java/org/pentaho/platform/scheduler2/action/ActionRunnerTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/action/ActionRunnerTest.java
@@ -38,7 +38,6 @@ import org.pentaho.platform.api.scheduler2.IBackgroundExecutionStreamProvider;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.security.SecurityHelper;
 import org.pentaho.platform.engine.services.actions.TestVarArgsAction;
-import org.pentaho.platform.scheduler2.quartz.SchedulerOutputPathResolver;
 import org.pentaho.platform.util.bean.TestAction;
 import org.pentaho.platform.util.messages.LocaleHelper;
 import org.powermock.api.mockito.PowerMockito;


### PR DESCRIPTION
the import `org.pentaho.platform.scheduler2.quartz.SchedulerOutputPathResolver` does not exist and/or the the dependency for it wasn't included.

However, there is the same class `SchedulerOutputPathResolver.java` in the test package `org.pentaho.platform.scheduler2.action`. That is how the code will know be able to compile.

yes, this class is a duplicate class, the original, in pentaho-platform/extensions - https://github.com/pentaho/pentaho-platform/blob/872a6c84e0230e603118a25b2fd5d52c01eb7e86/extensions/src/main/java/org/pentaho/platform/scheduler2/action/SchedulerOutputPathResolver.java

But that issue will have to be resolved later.