### PR TITLE
[BACKLOG-38225][BACKLOG-39275][BACKLOG-39299] Address Duplicate Class…

### DIFF
--- a/core/src/main/java/org/pentaho/platform/scheduler2/action/ActionRunner.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/action/ActionRunner.java
@@ -1,0 +1,270 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2002-2020 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.scheduler2.action;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.action.ActionInvocationException;
+import org.pentaho.platform.api.action.IAction;
+import org.pentaho.platform.api.action.IPostProcessingAction;
+import org.pentaho.platform.api.action.IStreamingAction;
+import org.pentaho.platform.api.action.IVarArgsAction;
+import org.pentaho.platform.api.repository.IContentItem;
+import org.pentaho.platform.api.repository2.unified.ISourcesStreamEvents;
+import org.pentaho.platform.api.repository2.unified.IStreamListener;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.scheduler2.IBackgroundExecutionStreamProvider;
+import org.pentaho.platform.engine.core.output.FileContentItem;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.engine.services.solution.ActionSequenceCompatibilityFormatter;
+import org.pentaho.platform.scheduler2.messsages.Messages;
+import org.pentaho.platform.util.ActionUtil;
+import org.pentaho.platform.util.beans.ActionHarness;
+import org.pentaho.platform.util.messages.LocaleHelper;
+import org.pentaho.platform.workitem.WorkItemLifecycleEventUtil;
+import org.pentaho.platform.workitem.WorkItemLifecyclePhase;
+
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+public class ActionRunner implements Callable<Boolean> {
+
+  private static final Log logger = LogFactory.getLog( ActionRunner.class );
+
+  private Map<String, Serializable> params;
+  private IAction actionBean;
+  private IBackgroundExecutionStreamProvider streamProvider;
+  private String actionUser;
+
+  private String outputFilePath = null;
+  private boolean streamComplete = false;
+  private Object lock = new Object();
+
+  public ActionRunner( final IAction actionBean, final String actionUser, final Map<String, Serializable> params, final
+    IBackgroundExecutionStreamProvider streamProvider ) {
+    this.actionBean = actionBean;
+    this.actionUser = actionUser;
+    this.params = params;
+    this.streamProvider = streamProvider;
+  }
+
+  public Boolean call() throws ActionInvocationException {
+    final String workItemName = ActionUtil.extractName( params );
+    try {
+      final ExecutionResult result = callImpl();
+      if ( result.isSuccess() ) {
+        WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.SUCCEEDED );
+      } else {
+        WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.FAILED );
+      }
+      return result.updateRequired();
+    } catch ( final Throwable t ) {
+      // ensure that the main thread isn't blocked on lock
+      synchronized ( lock ) {
+        lock.notifyAll();
+      }
+      WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.FAILED, t.toString() );
+      // We should not distinguish between checked and unchecked exceptions here. All job execution failures
+      // should result in a rethrow of the exception
+      throw new ActionInvocationException( Messages.getInstance().getActionFailedToExecute( actionBean //$NON-NLS-1$
+        .getClass().getName() ), t );
+    }
+  }
+
+  private ExecutionResult callImpl() throws Exception {
+    boolean executionStatus = true;
+
+    final Object locale = params.get( LocaleHelper.USER_LOCALE_PARAM );
+    if ( locale instanceof Locale ) {
+      LocaleHelper.setThreadLocaleOverride( (Locale) locale );
+    } else {
+      LocaleHelper.setThreadLocaleOverride( new Locale( (String) locale ) );
+    }
+    // sync job params to the action bean
+    ActionHarness actionHarness = new ActionHarness( actionBean );
+
+    final Map<String, Object> actionParams = new HashMap<>();
+    actionParams.putAll( params );
+    if ( streamProvider != null ) {
+      actionParams.put( "inputStream", streamProvider.getInputStream() );
+    }
+    actionHarness.setValues( actionParams, new ActionSequenceCompatibilityFormatter() );
+
+    if ( actionBean instanceof IVarArgsAction ) {
+      actionParams.remove( "inputStream" );
+      actionParams.remove( "outputStream" );
+      ( (IVarArgsAction) actionBean ).setVarArgs( actionParams );
+    }
+
+    boolean waitForFileCreated = false;
+    OutputStream stream = null;
+
+    if ( streamProvider != null ) {
+      actionParams.remove( "inputStream" );
+      if ( actionBean instanceof IStreamingAction ) {
+        streamProvider.setStreamingAction( (IStreamingAction) actionBean );
+      }
+
+      // BISERVER-9414 - validate that output path still exist
+      SchedulerOutputPathResolver resolver =
+        new SchedulerOutputPathResolver( streamProvider.getOutputPath(), actionUser );
+      String outputPath = resolver.resolveOutputFilePath();
+
+      if ( outputPath == null ) {
+        return new ExecutionResult( true, false );
+      }
+
+      actionParams.put( "useJcr", Boolean.TRUE );
+      actionParams.put( "jcrOutputPath", outputPath.substring( 0, outputPath.lastIndexOf( "/" ) ) );
+
+      if ( !outputPath.equals( streamProvider.getOutputPath() ) ) {
+        streamProvider.setOutputFilePath( outputPath ); // set fallback path
+        // Job output path requires update. The update triggers a new job that will fulfill the execution.
+        return new ExecutionResult( true, true );
+      }
+
+      stream = streamProvider.getOutputStream();
+      if ( stream instanceof ISourcesStreamEvents ) {
+        ( (ISourcesStreamEvents) stream ).addListener( new IStreamListener() {
+          public void fileCreated( final String filePath ) {
+            synchronized ( lock ) {
+              outputFilePath = filePath;
+              lock.notifyAll();
+            }
+          }
+
+          @Override
+          public void streamComplete() {
+            synchronized ( lock ) {
+              lock.notifyAll();
+              streamComplete = true;
+            }
+          }
+        } );
+        waitForFileCreated = true;
+      }
+      actionParams.put( "outputStream", stream );
+      actionHarness.setValues( actionParams );
+    }
+
+    actionBean.execute();
+    executionStatus = actionBean.isExecutionSuccessful();
+    if ( stream != null ) {
+      IOUtils.closeQuietly( stream );
+    }
+
+    if ( waitForFileCreated ) {
+      synchronized ( lock ) {
+        while ( outputFilePath == null && !streamComplete ) {
+          lock.wait( 1000 );
+        }
+      }
+      ActionUtil.sendEmail( actionParams, params, outputFilePath );
+      deleteFileIfEmpty();
+    }
+    if ( actionBean instanceof IPostProcessingAction ) {
+      closeContentOutputStreams( (IPostProcessingAction) actionBean );
+      markContentAsGenerated( (IPostProcessingAction) actionBean );
+    }
+
+    // Create the ExecutionResult to return the status and whether the update is required or not
+    return new ExecutionResult( false, executionStatus );
+  }
+
+  @VisibleForTesting
+  void deleteFileIfEmpty() {
+    if ( outputFilePath == null ) {
+      return;
+    }
+    IUnifiedRepository repo = PentahoSystem.get( IUnifiedRepository.class );
+    RepositoryFile file = repo.getFile( outputFilePath );
+    if ( file.getFileSize().equals( 0L ) ) {
+      repo.deleteFile( file.getId(), true, null );
+    }
+  }
+
+  private void closeContentOutputStreams( IPostProcessingAction actionBean ) {
+    for ( IContentItem contentItem : actionBean.getActionOutputContents() ) {
+      contentItem.closeOutputStream();
+    }
+  }
+
+  private void markContentAsGenerated( IPostProcessingAction actionBean ) {
+    IUnifiedRepository repo = PentahoSystem.get( IUnifiedRepository.class );
+    String lineageId = (String) params.get( ActionUtil.QUARTZ_LINEAGE_ID );
+    for ( IContentItem contentItem : actionBean.getActionOutputContents() ) {
+      RepositoryFile sourceFile = getRepositoryFileSafe( repo, contentItem.getPath() );
+      // add metadata if we have access and we have file
+      if ( sourceFile != null ) {
+        Map<String, Serializable> metadata = repo.getFileMetadata( sourceFile.getId() );
+        metadata.put( ActionUtil.QUARTZ_LINEAGE_ID, lineageId );
+        repo.setFileMetadata( sourceFile.getId(), metadata );
+      } else {
+        String fileName = getFSFileNameSafe( contentItem );
+        logger.warn( Messages.getInstance().getSkipRemovingOutputFile( fileName ) );
+      }
+    }
+  }
+
+  private RepositoryFile getRepositoryFileSafe( IUnifiedRepository repo, String path ) {
+    try {
+      return repo.getFile( path );
+    } catch ( Exception e ) {
+      logger.debug( Messages.getInstance().getCannotGetRepoFile( path, e.getMessage() ) );
+      return null;
+    }
+  }
+
+  private String getFSFileNameSafe( IContentItem contentItem ) {
+    if ( contentItem instanceof FileContentItem ) {
+      return ( (FileContentItem) contentItem ).getFile().getName();
+    }
+    return null;
+  }
+
+  /**
+   * Class to hold the result of the invoke Action
+   */
+  private class ExecutionResult {
+    private boolean updateRequired;
+    private boolean isSuccess;
+
+    public ExecutionResult( Boolean updateRequired, Boolean isSuccess ) {
+      this.updateRequired = updateRequired;
+      this.isSuccess = isSuccess;
+    }
+    public Boolean updateRequired() {
+      return updateRequired;
+    }
+
+    public Boolean isSuccess() {
+      return isSuccess;
+    }
+
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/scheduler2/action/DefaultActionInvoker.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/action/DefaultActionInvoker.java
@@ -1,0 +1,163 @@
+package org.pentaho.platform.scheduler2.action;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.action.ActionInvokeStatus;
+import org.pentaho.platform.api.action.ActionInvocationException;
+import org.pentaho.platform.api.action.IAction;
+import org.pentaho.platform.api.action.IActionInvokeStatus;
+import org.pentaho.platform.api.action.IActionInvoker;
+import org.pentaho.platform.api.scheduler2.IBackgroundExecutionStreamProvider;
+import org.pentaho.platform.api.scheduler2.IScheduler;
+import org.pentaho.platform.engine.security.SecurityHelper;
+import org.pentaho.platform.scheduler2.messsages.Messages;
+import org.pentaho.platform.util.ActionUtil;
+import org.pentaho.platform.util.StringUtil;
+import org.pentaho.platform.util.messages.LocaleHelper;
+import org.pentaho.platform.workitem.WorkItemLifecycleEventUtil;
+import org.pentaho.platform.workitem.WorkItemLifecyclePhase;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * A concrete implementation of the {@link IActionInvoker} interface that invokes the {@link IAction} locally.
+ */
+public class DefaultActionInvoker implements IActionInvoker {
+
+  private static final Log logger = LogFactory.getLog( DefaultActionInvoker.class );
+
+  /**
+   * Gets the stream provider from the {@code RESERVEDMAPKEY_STREAMPROVIDER} key within the {@code params} {@link Map}.
+   *
+   * @param params the {@link Map} or parameters needed to invoke the {@link IAction}
+   * @return a {@link IBackgroundExecutionStreamProvider} represented in the {@code params} {@link Map}
+   */
+  protected IBackgroundExecutionStreamProvider getStreamProvider( final Map<String, Serializable> params ) {
+    if ( params == null ) {
+      logger.warn( Messages.getInstance().getMapNullCantReturnSp() );
+      return null;
+    }
+
+    final Object obj = params.get( IScheduler.RESERVEDMAPKEY_STREAMPROVIDER );
+    return ( obj instanceof IBackgroundExecutionStreamProvider ) ? (IBackgroundExecutionStreamProvider) obj : null;
+  }
+
+  /**
+   *
+   * Validates that the conditions required for the {@link IAction} to be invoked are true, throwing an
+   * {@link ActionInvocationException}, if the conditions are not met.
+   *
+   * @param actionBean The {@link IAction} to be invoked
+   * @param actionUser The user invoking the {@link IAction}
+   * @param params     the {@link Map} or parameters needed to invoke the {@link IAction}
+   * @return the {@link IActionInvokeStatus} object containing information about the action invocation
+   * @throws ActionInvocationException when conditions needed to invoke the {@link IAction} are not met
+   */
+  public void validate( final IAction actionBean, final String actionUser,
+                        final Map<String, Serializable> params ) throws ActionInvocationException {
+
+    final String workItemName = ActionUtil.extractName( params );
+
+    if ( actionBean == null || params == null ) {
+      final String failureMessage = Messages.getInstance().getCantInvokeNullAction();
+      WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.FAILED,  failureMessage );
+      throw new ActionInvocationException( failureMessage );
+    }
+
+    if ( !isSupportedAction( actionBean ) ) {
+      final String failureMessage = Messages.getInstance().getUnsupportedAction( actionBean.getClass().getName() );
+      WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.FAILED, failureMessage );
+      throw new ActionInvocationException( failureMessage );
+    }
+  }
+
+  /**
+   * Invokes the provided {@link IAction} as the provided {@code actionUser}.
+   *
+   * @param actionBean the {@link IAction} being invoked
+   * @param actionUser The user invoking the {@link IAction}
+   * @param params     the {@link Map} or parameters needed to invoke the {@link IAction}
+   * @return the {@link IActionInvokeStatus} object containing information about the action invocation
+   * @throws Exception when the {@code IAction} cannot be invoked for some reason.
+   */
+  @Override
+  public IActionInvokeStatus invokeAction( final IAction actionBean,
+                                           final String actionUser,
+                                           final Map<String, Serializable> params ) throws Exception {
+    validate( actionBean, actionUser, params );
+    return invokeActionImpl( actionBean, actionUser, params );
+  }
+
+  /**
+   * Invokes the provided {@link IAction} as the provided {@code actionUser}.
+   *
+   * @param actionBean the {@link IAction} being invoked
+   * @param actionUser The user invoking the {@link IAction}
+   * @param params     the {@link Map} or parameters needed to invoke the {@link IAction}
+   * @return the {@link IActionInvokeStatus} object containing information about the action invocation
+   * @throws Exception when the {@code IAction} cannot be invoked for some reason.
+   */
+  protected IActionInvokeStatus invokeActionImpl( final IAction actionBean,
+                                           final String actionUser,
+                                           final Map<String, Serializable> params ) throws Exception {
+
+    final String workItemName = ActionUtil.extractName( params );
+
+    if ( actionBean == null || params == null ) {
+      final String failureMessage = Messages.getInstance().getCantInvokeNullAction();
+      WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.FAILED, failureMessage );
+      throw new ActionInvocationException( failureMessage );
+    }
+
+    WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.IN_PROGRESS );
+
+    if ( logger.isDebugEnabled() ) {
+      logger.debug( Messages.getInstance().getRunningInBackgroundLocally( actionBean.getClass().getName(), params ) );
+    }
+
+    // set the locale, if not already set
+    if ( params.get( LocaleHelper.USER_LOCALE_PARAM ) == null || StringUtils.isEmpty(
+      params.get( LocaleHelper.USER_LOCALE_PARAM ).toString() ) ) {
+      params.put( LocaleHelper.USER_LOCALE_PARAM, LocaleHelper.getLocale() );
+    }
+
+    // remove the scheduling infrastructure properties
+    ActionUtil.removeKeyFromMap( params, ActionUtil.INVOKER_ACTIONCLASS );
+    ActionUtil.removeKeyFromMap( params, ActionUtil.INVOKER_ACTIONID );
+    ActionUtil.removeKeyFromMap( params, ActionUtil.INVOKER_ACTIONUSER );
+    // build the stream provider
+    final IBackgroundExecutionStreamProvider streamProvider = getStreamProvider( params );
+    ActionUtil.removeKeyFromMap( params, ActionUtil.INVOKER_STREAMPROVIDER );
+    ActionUtil.removeKeyFromMap( params, ActionUtil.INVOKER_UIPASSPARAM );
+
+    final ActionRunner
+      actionBeanRunner = new ActionRunner( actionBean, actionUser, params, streamProvider );
+    final IActionInvokeStatus status = new ActionInvokeStatus();
+    status.setStreamProvider( streamProvider );
+
+    boolean requiresUpdate = false;
+    try {
+      if ( ( StringUtil.isEmpty( actionUser ) ) || ( actionUser.equals( "system session" ) ) ) { //$NON-NLS-1$
+        // For now, don't try to run quartz jobs as authenticated if the user
+        // that created the job is a system user. See PPP-2350
+        requiresUpdate = SecurityHelper.getInstance().runAsAnonymous( actionBeanRunner );
+      } else {
+        requiresUpdate = SecurityHelper.getInstance().runAsUser( actionUser, actionBeanRunner );
+      }
+    } catch ( final Throwable t ) {
+      WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.FAILED, t.toString() );
+      status.setThrowable( t );
+    }
+    status.setRequiresUpdate( requiresUpdate );
+    // Set the execution Status
+    status.setExecutionStatus( actionBean.isExecutionSuccessful() );
+    return status;
+  }
+
+  @Override
+  public boolean isSupportedAction( IAction action ) {
+    return true; // supports all
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/scheduler2/action/SchedulerOutputPathResolver.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/action/SchedulerOutputPathResolver.java
@@ -1,0 +1,209 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.scheduler2.action;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.engine.IAuthorizationPolicy;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.repository.IClientRepositoryPathsStrategy;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
+import org.pentaho.platform.api.scheduler2.SchedulerException;
+import org.pentaho.platform.api.usersettings.IUserSettingService;
+import org.pentaho.platform.api.usersettings.pojo.IUserSetting;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.engine.security.SecurityHelper;
+import org.pentaho.platform.scheduler2.messsages.Messages;
+
+/**
+ * @author Rowell Belen
+ */
+public class SchedulerOutputPathResolver {
+
+  final String DEFAULT_SETTING_KEY = "default-scheduler-output-path";
+  public static final String SCHEDULER_ACTION_NAME = "org.pentaho.scheduler.manage";
+
+  private static final Log logger = LogFactory.getLog( SchedulerOutputPathResolver.class );
+  private static final List<RepositoryFilePermission> permissions = new ArrayList<RepositoryFilePermission>();
+
+  private String jobName;
+  private String outputDirectory;
+  private String actionUser;
+
+  static {
+    // initialize permissions
+    permissions.add( RepositoryFilePermission.READ );
+    permissions.add( RepositoryFilePermission.WRITE );
+  }
+
+  public SchedulerOutputPathResolver( final String outputPathPattern, final String actionUser ) {
+    this.jobName = FilenameUtils.getBaseName( outputPathPattern );
+    this.outputDirectory = FilenameUtils.getPathNoEndSeparator( outputPathPattern );
+    this.actionUser = actionUser;
+  }
+
+  public String resolveOutputFilePath() {
+
+    final String fileNamePattern = "/" + this.jobName + ".*";
+    final String outputFilePath = "/" + this.outputDirectory;
+
+    // Enclose validation logic in the context of the job creator's session, not the current session
+    final Callable<String> callable = new Callable<String>() {
+      @Override
+      public String call() throws Exception {
+
+        if ( StringUtils.isNotBlank( outputFilePath ) && isValidOutputPath( outputFilePath )
+            && isPermitted( outputFilePath ) ) {
+          return outputFilePath + fileNamePattern; // return if valid
+        }
+
+        // evaluate fallback output paths
+        String[] fallBackPaths = new String[] { getUserSettingOutputPath(), // user setting
+          getSystemSettingOutputPath(), // system setting
+          getUserHomeDirectoryPath() // home directory
+        };
+
+        for ( String path : fallBackPaths ) {
+          if ( StringUtils.isNotBlank( path ) && isValidOutputPath( path ) ) {
+            return path + fileNamePattern; // return the first valid path
+          }
+        }
+
+        return null; // it should never reach here because the user directory is the ultimate fallback
+      }
+    };
+
+    return runAsUser( callable );
+  }
+
+  private String runAsUser( Callable<String> callable ) {
+    try {
+      if ( callable != null ) {
+        return SecurityHelper.getInstance().runAsUser( this.actionUser, callable );
+      }
+    } catch ( Exception e ) {
+      logger.error( e.getMessage(), e );
+    }
+
+    return null;
+  }
+
+  private boolean isValidOutputPath( String path ) throws SchedulerException {
+    try {
+      RepositoryFile repoFile = getRepository().getFile( path );
+      if ( repoFile != null && repoFile.isFolder() ) {
+        boolean scheduleAllowed = isScheduleAllowed( repoFile.getId() );
+        if ( scheduleAllowed ) {
+          return true;
+        } else {
+          throw new SchedulerException( Messages.getInstance().getString(
+            "QuartzScheduler.ERROR_0009_SCHEDULING_IS_NOT_ALLOWED_AFTER_CHANGE", this.jobName, this.actionUser ) );
+        }
+      }
+    } catch ( Exception e ) {
+      logger.warn( e.getMessage(), e );
+    }
+    return false;
+  }
+
+  private String getUserSettingOutputPath() {
+    try {
+      IUserSetting userSetting = getUserSettingService().getUserSetting( DEFAULT_SETTING_KEY, null );
+      if ( userSetting != null && StringUtils.isNotBlank( userSetting.getSettingValue() ) ) {
+        return userSetting.getSettingValue();
+      }
+    } catch ( Exception e ) {
+      logger.warn( e.getMessage(), e );
+    }
+    return null;
+  }
+
+  private String getSystemSettingOutputPath() {
+    try {
+      return PentahoSystem.getSystemSettings().getSystemSetting( DEFAULT_SETTING_KEY, null );
+    } catch ( Exception e ) {
+      logger.warn( e.getMessage(), e );
+    }
+    return null;
+  }
+
+  private String getUserHomeDirectoryPath() {
+    try {
+      IClientRepositoryPathsStrategy pathsStrategy =
+          PentahoSystem.get( IClientRepositoryPathsStrategy.class, getScheduleCreatorSession() );
+      return pathsStrategy.getUserHomeFolderPath( getScheduleCreatorSession().getName() );
+    } catch ( Exception e ) {
+      logger.warn( e.getMessage(), e );
+    }
+    return null;
+  }
+
+  private IPentahoSession getScheduleCreatorSession() {
+    return PentahoSessionHolder.getSession();
+  }
+
+  private IUnifiedRepository getRepository() {
+    return PentahoSystem.get( IUnifiedRepository.class, getScheduleCreatorSession() );
+  }
+
+  private IUserSettingService getUserSettingService() {
+    return PentahoSystem.get( IUserSettingService.class, getScheduleCreatorSession() );
+  }
+
+  private IAuthorizationPolicy getAuthorizationPolicy() {
+    return PentahoSystem.get( IAuthorizationPolicy.class, getScheduleCreatorSession() );
+  }
+
+  private boolean isScheduleAllowed( final Serializable repositoryId ) {
+    boolean canSchedule = false;
+    canSchedule = getAuthorizationPolicy().isAllowed( SCHEDULER_ACTION_NAME );
+    if ( canSchedule ) {
+      Map<String, Serializable> metadata = getRepository().getFileMetadata( repositoryId );
+      if ( metadata.containsKey( RepositoryFile.SCHEDULABLE_KEY ) ) {
+        canSchedule = BooleanUtils.toBoolean( (String) metadata.get( RepositoryFile.SCHEDULABLE_KEY ) );
+      }
+    }
+
+    return canSchedule;
+  }
+
+  private boolean isPermitted( final String path ) {
+    try {
+      return getRepository().hasAccess( path, EnumSet.copyOf( permissions ) );
+    } catch ( Exception e ) {
+      logger.warn( e.getMessage(), e );
+    }
+    return false;
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/scheduler2/messsages/Messages.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/messsages/Messages.java
@@ -1,0 +1,136 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2002-2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.scheduler2.messsages;
+
+import org.pentaho.platform.util.StringUtil;
+import org.pentaho.platform.util.messages.LocaleHelper;
+import org.pentaho.platform.util.messages.MessageUtil;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+/**
+ * Wrapper class for i18n messages.
+ */
+public class Messages implements Serializable {
+
+  private static final String BUNDLE_NAME = Messages.class.getPackage().getName() + ".messages"; //$NON-NLS-1$
+  private static final long serialVersionUID = 2701028757443485586L;
+
+  private static Messages instance = new Messages();
+
+  public static Messages getInstance() {
+    return instance;
+  }
+
+  private static final Map<Locale, ResourceBundle> locales = Collections
+    .synchronizedMap( new HashMap<Locale, ResourceBundle>() );
+
+  /*
+   * NOTE: Do not extend pentaho-platform-extension's org.pentaho.platform.util.messages.MessagesBase.
+   * With current Pentaho's plugin, Message.properties files will not be found by ResourceBundle#getBundle.
+   * Most likely when deployed, pentaho-platform-extension and other plugin's jar are in different folders.
+   */
+  private static ResourceBundle getBundle() {
+    Locale locale = LocaleHelper.getLocale();
+    ResourceBundle bundle = Messages.locales.get( locale );
+    if ( bundle == null ) {
+      bundle = ResourceBundle.getBundle( Messages.BUNDLE_NAME, locale );
+      Messages.locales.put( locale, bundle );
+    }
+    return bundle;
+  }
+
+  public static String getString( final String key ) {
+    try {
+      return Messages.getBundle().getString( key );
+    } catch ( MissingResourceException e ) {
+      return '!' + key + '!';
+    }
+  }
+
+  public String getString( final String key, final String param1 ) {
+    return MessageUtil.getString( Messages.getBundle(), key, param1 );
+  }
+
+  public String getString( final String key, final String param1, final String param2 ) {
+    return MessageUtil.getString( Messages.getBundle(), key, param1, param2 );
+  }
+
+  public String getString( final String key, final String param1, final String param2, final String param3 ) {
+    return MessageUtil.getString( Messages.getBundle(), key, param1, param2, param3 );
+  }
+
+  public String getString( final String key, final String param1, final String param2, final String param3,
+                           final String param4 ) {
+    return MessageUtil.getString( Messages.getBundle(), key, param1, param2, param3, param4 );
+  }
+
+  public  String getErrorString( final String key ) {
+    return MessageUtil.formatErrorMessage( key, Messages.getString( key ) );
+  }
+
+  public String getErrorString( final String key, final String param1 ) {
+    return MessageUtil.getErrorString( Messages.getBundle(), key, param1 );
+  }
+
+  public String getErrorString( final String key, final String param1, final String param2 ) {
+    return MessageUtil.getErrorString( Messages.getBundle(), key, param1, param2 );
+  }
+
+  public String getErrorString( final String key, final String param1, final String param2, final String param3 ) {
+    return MessageUtil.getErrorString( Messages.getBundle(), key, param1, param2, param3 );
+  }
+
+  public String getRunningInBackgroundLocally( final String actionIdentifier, final Map params ) {
+    return getString( "ActionInvoker.INFO_0001_RUNNING_IN_BG_LOCALLY", actionIdentifier,
+      StringUtil.getMapAsPrettyString( params ) );
+  }
+
+  public String getUnsupportedAction( final String action ) {
+    return getErrorString( "ActionInvoker.ERROR_0006_ACTION_NULL", action );
+  }
+
+  public String getCantInvokeNullAction() {
+    return getErrorString( "ActionInvoker.ERROR_0005_ACTION_NULL" );
+  }
+
+  public String getActionFailedToExecute( final String actionIdentifier ) {
+    return getErrorString( "ActionInvoker.ERROR_0004_ACTION_FAILED", actionIdentifier );
+  }
+
+  public String getSkipRemovingOutputFile( final String fileName ) {
+    return getString( "ActionInvoker.WARN_0001_SKIP_REMOVING_OUTPUT_FILE", fileName );
+  }
+
+  public String getCannotGetRepoFile( final String fileName, final String msg ) {
+    return getErrorString( "ActionInvoker.ERROR_0010_CANNOT_GET_REPO_FILE", fileName, msg );
+  }
+
+  public String getMapNullCantReturnSp() {
+    return getErrorString( "ActionInvoker.ERROR_0008_MAP_NULL_CANT_RETURN_SP" );
+  }
+}


### PR DESCRIPTION
…es in Artifacts pentaho-scheduler-core, pentaho-platform-extensions, pentaho-platform-scheduler

- adding package here from pentaho-platform/extensions/src/main/java/org/pentaho/platform/scheduler2

From my analysis, the reason why this package couldn't be moved over was due to cyclic dependency caused by LocalActionInvoker.java which will be removed with - https://github.com/pentaho/pentaho-platform/pull/5465 , see jira comment for more details - https://hv-eng.atlassian.net/browse/BACKLOG-39275?focusedCommentId=1914613