### PR TITLE
[BACKLOG-37872] Added Generic File service and Repository provider

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>pentaho</groupId>
+        <artifactId>pentaho-scheduler-plugin-parent</artifactId>
+        <version>10.1.0.0-SNAPSHOT</version>
+    </parent>
+    <groupId>pentaho</groupId>
+    <artifactId>pentaho-scheduler-api</artifactId>
+    <version>10.1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+    </dependencies>
+    <build>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>${maven.compiler.target}</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
@@ -1,0 +1,45 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.api.genericfile;
+
+import org.pentaho.platform.api.genericfile.model.IGenericFile;
+import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
+
+public interface IGenericFileProvider<T extends IGenericFile> {
+
+  Class<T> getFileClass();
+
+  String getName();
+
+  String getType();
+
+  boolean isAvailable();
+
+  IGenericFileTree getFolders( Integer depth );
+
+  void clearFolderCache();
+
+  boolean doesFolderExist( String path );
+
+  boolean createFolder( String path );
+
+  boolean owns( String path );
+}

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java
@@ -1,0 +1,33 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.api.genericfile;
+
+import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
+
+public interface IGenericFileService {
+  void clearFolderCache();
+
+  IGenericFileTree getFolders( Integer depth );
+
+  boolean doesFolderExist( String path );
+
+  boolean createFolder( String path );
+}

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/exception/GenericFileException.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/exception/GenericFileException.java
@@ -1,0 +1,24 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.api.genericfile.exception;
+
+public class GenericFileException extends Exception {
+}

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/exception/GenericFileNotFoundException.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/exception/GenericFileNotFoundException.java
@@ -1,0 +1,47 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.api.genericfile.exception;
+
+public class GenericFileNotFoundException extends GenericFileException {
+  private String path;
+  private String provider;
+
+  public GenericFileNotFoundException( String path, String provider ) {
+    this.path = path;
+    this.provider = provider;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath( String path ) {
+    this.path = path;
+  }
+
+  public String getProvider() {
+    return provider;
+  }
+
+  public void setProvider( String provider ) {
+    this.provider = provider;
+  }
+}

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/exception/InvalidGenericFileProviderException.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/exception/InvalidGenericFileProviderException.java
@@ -1,0 +1,24 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.api.genericfile.exception;
+
+public class InvalidGenericFileProviderException extends Exception {
+}

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFile.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFile.java
@@ -1,0 +1,49 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.api.genericfile.model;
+
+import java.util.Date;
+
+public interface IGenericFile extends IProviderable {
+  String TYPE_FOLDER = "folder";
+  String TYPE_FILE = "file";
+
+  String getName();
+  String getPath();
+  String getParent();
+  String getType();
+
+  default boolean isFolder() {
+    return TYPE_FOLDER.equals( getType() );
+  }
+
+  Date getModifiedDate();
+  boolean isCanEdit();
+  boolean isCanDelete();
+
+  default IGenericFolder asFolder() {
+    return null;
+  }
+
+  String getTitle();
+
+  String getDescription();
+}

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFileTree.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFileTree.java
@@ -1,0 +1,29 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.api.genericfile.model;
+
+import java.util.List;
+
+public interface IGenericFileTree extends IProviderable {
+  IGenericFile getFile();
+  List<IGenericFileTree> getChildren();
+  void addChild( IGenericFileTree child );
+}

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFolder.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFolder.java
@@ -1,0 +1,38 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.api.genericfile.model;
+
+public interface IGenericFolder extends IGenericFile {
+  @Override
+  default String getType() {
+    return TYPE_FOLDER;
+  }
+
+  @Override
+  default IGenericFolder asFolder() {
+    return this;
+  }
+
+  boolean isCanAddChildren();
+  default boolean isHasChildren() {
+    return true;
+  }
+}

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/model/IProviderable.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/model/IProviderable.java
@@ -1,0 +1,26 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.api.genericfile.model;
+
+
+public interface IProviderable {
+  String getProvider();
+}

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -24,6 +24,18 @@
             <artifactId>quartz-oracle</artifactId>
             <version>${quartz-oracle.version}</version>
         </dependency>
+        <dependency>
+            <groupId>pentaho</groupId>
+            <artifactId>pentaho-scheduler-core</artifactId>
+            <version>${pentaho-scheduler-plugin.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>pentaho</groupId>
+            <artifactId>pentaho-scheduler-api</artifactId>
+            <version>${pentaho-scheduler-plugin.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/assembly/src/assembly/assembly.xml
+++ b/assembly/src/assembly/assembly.xml
@@ -17,6 +17,7 @@
       <!-- Now, select which projects to include in this module-set. -->
       <includes>
         <include>pentaho:pentaho-scheduler-core</include>
+        <include>pentaho:pentaho-scheduler-api</include>
         <include>org.quartz-scheduler:quartz</include>
         <include>org.quartz-schedule:quartz-oracle</include>
       </includes>

--- a/assembly/src/main/plugin.spring.xml
+++ b/assembly/src/main/plugin.spring.xml
@@ -20,9 +20,9 @@ prohibited to anyone except those individuals and entities who have executed
 confidentiality and non-disclosure agreements or other agreements with Hitachi Vantara,
 explicitly covering such access.
 ============================================================================-->
-<!-- 
-This is a Spring file that defines how Pentaho system objects are created and managed.  
-An implementation of IPentahoObjectFactory, such as WebSpringPentahoObjectFactory, is 
+<!--
+This is a Spring file that defines how Pentaho system objects are created and managed.
+An implementation of IPentahoObjectFactory, such as WebSpringPentahoObjectFactory, is
 responsible for serving objects to callers based on this file.
 
 Possible values for scope attribute:
@@ -30,7 +30,7 @@ Possible values for scope attribute:
 *prototype* - each request for this object returns a new instance
 *session* - each request for this object within a session returns the same instance
 
-default-lazy-init is set to true since some of these object make calls into 
+default-lazy-init is set to true since some of these object make calls into
 PentahoSystem which is initialized after Spring
  -->
 <beans xmlns="http://www.springframework.org/schema/beans"
@@ -40,13 +40,15 @@ PentahoSystem which is initialized after Spring
        xmlns:ws="http://jax-ws.dev.java.net/spring/core"
        xmlns:wss="http://jax-ws.dev.java.net/spring/servlet"
        xmlns:pen="http://www.pentaho.com/schema/pentaho-system"
+       xmlns:swm="http://www.hitachivantara.com/schema/security/web/model/spring"
        xsi:schemaLocation="
             http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
             http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.3.xsd
             http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd
             http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.3.xsd
             http://jax-ws.dev.java.net/spring/core http://jax-ws.dev.java.net/spring/core.xsd
-            http://jax-ws.dev.java.net/spring/servlet http://jax-ws.dev.java.net/spring/servlet.xsd"
+            http://jax-ws.dev.java.net/spring/servlet http://jax-ws.dev.java.net/spring/servlet.xsd
+            http://www.hitachivantara.com/schema/security/web/model/spring http://www.hitachivantara.com/schema/security/web/model/spring/hv-swm-spring.xsd"
        default-lazy-init="true">
 
 
@@ -81,4 +83,23 @@ PentahoSystem which is initialized after Spring
         class="org.pentaho.platform.plugin.services.exporter.ScheduleExportUtil"
         init-method="registerAsHelper"
         lazy-init="false"/>
+  <bean class="org.pentaho.platform.web.http.api.resources.GenericFileResource" autowire="constructor" scope="session"/>
+  <bean class="org.pentaho.platform.genericfile.DefaultGenericFileService" autowire="constructor" scope="session">
+    <!-- Allow getting bean from interface via PentahoSystem.get(.) -->
+    <pen:publish as-type="INTERFACES"/>
+  </bean>
+  <bean class="org.pentaho.platform.genericfile.providers.repository.RepositoryFileProvider" scope="session"/>
+
+  <!-- CSRF protection. To disable, comment out the bean. -->
+  <bean class="com.hitachivantara.security.web.impl.model.csrf.CsrfRequestSetConfigurationPojo">
+    <pen:publish as-type="INTERFACES"/>
+
+    <constructor-arg>
+      <!--
+          POST /plugin/scheduler-plugin/api/generic-files/folders/:home:admin
+        -->
+      <swm:regex-request-matcher pattern="^/plugin/scheduler-plugin/api/generic-files/folders/[^/]*\b.*"
+              methods="POST"/>
+  </constructor-arg>
+</bean>
 </beans>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -82,6 +82,10 @@
       <version>9.1.6</version>
     </dependency>
     <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.pentaho</groupId>
       <artifactId>pentaho-metadata</artifactId>
       <version>${project.version}</version>
@@ -214,6 +218,12 @@
       <scope>compile</scope>
     </dependency>
     <!-- endregion -->
+    <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>pentaho-scheduler-api</artifactId>
+      <version>10.1.0.0-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/core/src/main/java/org/pentaho/platform/genericfile/DefaultGenericFileService.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/DefaultGenericFileService.java
@@ -1,0 +1,104 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.genericfile;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.pentaho.platform.api.genericfile.IGenericFileProvider;
+import org.pentaho.platform.api.genericfile.IGenericFileService;
+import org.pentaho.platform.api.genericfile.exception.InvalidGenericFileProviderException;
+import org.pentaho.platform.api.genericfile.model.IGenericFile;
+import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
+import org.pentaho.platform.genericfile.model.BaseGenericFile;
+import org.pentaho.platform.genericfile.model.BaseGenericFileTree;
+import org.pentaho.platform.util.StringUtil;
+
+import java.util.List;
+import java.util.Objects;
+
+public class DefaultGenericFileService implements IGenericFileService {
+
+  private final List<IGenericFileProvider<?>> fileProviders;
+
+  public DefaultGenericFileService( @NonNull List<IGenericFileProvider<?>> fileProviders )
+    throws InvalidGenericFileProviderException {
+    Objects.requireNonNull( fileProviders );
+    if ( fileProviders.isEmpty() ) {
+      throw new InvalidGenericFileProviderException();
+    }
+
+    this.fileProviders = fileProviders;
+  }
+
+  public void clearFolderCache() {
+    for ( IGenericFileProvider<?> fileProvider : fileProviders ) {
+      fileProvider.clearFolderCache();
+    }
+  }
+
+  public IGenericFileTree getFolders( Integer depth ) {
+    if ( fileProviders.size() > 1 ) {
+      BaseGenericFile entity = new BaseGenericFile();
+      entity.setName( "root" );
+      entity.setProvider( "combined" );
+      entity.setType( IGenericFile.TYPE_FOLDER );
+
+      BaseGenericFileTree rootTree = new BaseGenericFileTree( entity ) {
+        @Override
+        public String getProvider() {
+          return "combined";
+        }
+      };
+
+      for ( IGenericFileProvider<?> fileProvider : fileProviders ) {
+        if ( fileProvider.isAvailable() ) {
+          rootTree.addChild( fileProvider.getFolders( depth ) );
+        }
+      }
+
+      return rootTree;
+    } else {
+      return fileProviders.get( 0 ).getFolders( depth );
+    }
+  }
+
+  public boolean doesFolderExist( String path ) {
+    if ( !StringUtil.isEmpty( path ) ) {
+      for ( IGenericFileProvider<?> fileProvider : fileProviders ) {
+        if ( fileProvider.owns( path ) ) {
+          return fileProvider.doesFolderExist( path );
+        }
+      }
+    }
+    return false;
+  }
+
+
+  public boolean createFolder( String path ) {
+    if ( !StringUtil.isEmpty( path ) ) {
+      for ( IGenericFileProvider<?> fileProvider : fileProviders ) {
+        if ( fileProvider.owns( path ) ) {
+          return fileProvider.createFolder( path );
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/genericfile/messages/Messages.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/messages/Messages.java
@@ -1,0 +1,89 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2023 Hitachi Vantara.  All rights reserved.
+ */
+
+package org.pentaho.platform.genericfile.messages;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+import org.pentaho.platform.util.messages.LocaleHelper;
+import org.pentaho.platform.util.messages.MessageUtil;
+
+
+public class Messages {
+  private static final String BUNDLE_NAME = Messages.class.getPackage().getName() + ".messages"; //$NON-NLS-1$
+
+  private static final Map<Locale, ResourceBundle> locales =
+    Collections.synchronizedMap( new HashMap<Locale, ResourceBundle>() );
+
+  private static ResourceBundle getBundle() {
+    Locale locale = LocaleHelper.getLocale();
+    ResourceBundle bundle = Messages.locales.get( locale );
+    if ( bundle == null ) {
+      bundle = ResourceBundle.getBundle( Messages.BUNDLE_NAME, locale );
+      Messages.locales.put( locale, bundle );
+    }
+    return bundle;
+  }
+
+  public static String getString( final String key ) {
+    try {
+      return Messages.getBundle().getString( key );
+    } catch ( MissingResourceException e ) {
+      return '!' + key + '!';
+    }
+  }
+
+  public static String getString( final String key, final String param1 ) {
+    return MessageUtil.getString( Messages.getBundle(), key, param1 );
+  }
+
+  public static String getString( final String key, final String param1, final String param2 ) {
+    return MessageUtil.getString( Messages.getBundle(), key, param1, param2 );
+  }
+
+  public static String getString( final String key, final String param1, final String param2, final String param3 ) {
+    return MessageUtil.getString( Messages.getBundle(), key, param1, param2, param3 );
+  }
+
+  public static String getString( final String key, final String param1, final String param2, final String param3,
+                                  final String param4 ) {
+    return MessageUtil.getString( Messages.getBundle(), key, param1, param2, param3, param4 );
+  }
+
+  public static String getErrorString( final String key ) {
+    return MessageUtil.formatErrorMessage( key, Messages.getString( key ) );
+  }
+
+  public static String getErrorString( final String key, final String param1 ) {
+    return MessageUtil.getErrorString( Messages.getBundle(), key, param1 );
+  }
+
+  public static String getErrorString( final String key, final String param1, final String param2 ) {
+    return MessageUtil.getErrorString( Messages.getBundle(), key, param1, param2 );
+  }
+
+  public static String getErrorString( final String key, final String param1, final String param2,
+                                       final String param3 ) {
+    return MessageUtil.getErrorString( Messages.getBundle(), key, param1, param2, param3 );
+  }
+
+}

--- a/core/src/main/java/org/pentaho/platform/genericfile/model/BaseGenericFile.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/model/BaseGenericFile.java
@@ -1,0 +1,128 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.genericfile.model;
+
+import org.pentaho.platform.api.genericfile.model.IGenericFile;
+
+import java.util.Date;
+
+public class BaseGenericFile implements IGenericFile {
+  private String provider;
+  private String name;
+  private String path;
+  private String parent;
+  private String type;
+  private Date modifiedDate;
+  private boolean canEdit;
+  private boolean canDelete;
+  private String title;
+  private String description;
+
+  @Override
+  public String getProvider() {
+    return provider;
+  }
+
+  public void setProvider( String provider ) {
+    this.provider = provider;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  public void setName( String name ) {
+    this.name = name;
+  }
+
+  @Override
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath( String path ) {
+    this.path = path;
+  }
+
+  @Override
+  public String getParent() {
+    return parent;
+  }
+
+  public void setParent( String parent ) {
+    this.parent = parent;
+  }
+
+  @Override
+  public String getType() {
+    return type;
+  }
+
+  public void setType( String type ) {
+    this.type = type;
+  }
+
+  @Override
+  public Date getModifiedDate() {
+    return modifiedDate;
+  }
+
+  public void setModifiedDate( Date modifiedDate ) {
+    this.modifiedDate = modifiedDate;
+  }
+
+  @Override
+  public boolean isCanEdit() {
+    return canEdit;
+  }
+
+  public void setCanEdit( boolean canEdit ) {
+    this.canEdit = canEdit;
+  }
+
+  @Override
+  public boolean isCanDelete() {
+    return canDelete;
+  }
+
+  public void setCanDelete( boolean canDelete ) {
+    this.canDelete = canDelete;
+  }
+
+  @Override
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle( String title ) {
+    this.title = title;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription( String description ) {
+    this.description = description;
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/genericfile/model/BaseGenericFileTree.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/model/BaseGenericFileTree.java
@@ -1,0 +1,59 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.genericfile.model;
+
+import org.pentaho.platform.api.genericfile.model.IGenericFile;
+import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class BaseGenericFileTree implements IGenericFileTree {
+
+  protected IGenericFile file;
+  protected List<IGenericFileTree> children = new ArrayList<>();
+
+  protected BaseGenericFileTree( IGenericFile file ) {
+    this.file = file;
+  }
+
+  @Override
+  public IGenericFile getFile() {
+    return file;
+  }
+
+  public void setFile( IGenericFile file ) {
+    this.file = file;
+  }
+
+  public List<IGenericFileTree> getChildren() {
+    return children;
+  }
+
+  public void setChildren( List<IGenericFileTree> children ) {
+    this.children = children;
+  }
+
+  @Override
+  public void addChild( IGenericFileTree tree ) {
+    children.add( tree );
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/genericfile/model/BaseGenericFolder.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/model/BaseGenericFolder.java
@@ -1,0 +1,50 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.genericfile.model;
+
+import org.pentaho.platform.api.genericfile.model.IGenericFolder;
+
+public abstract class BaseGenericFolder extends BaseGenericFile implements IGenericFolder {
+  private boolean hasChildren;
+  private boolean canAddChildren;
+
+  protected BaseGenericFolder() {
+    setType( TYPE_FOLDER );
+  }
+
+  public boolean isHasChildren() {
+    return hasChildren;
+  }
+
+  public void setHasChildren( boolean hasChildren ) {
+    this.hasChildren = hasChildren;
+  }
+
+
+  @Override
+  public boolean isCanAddChildren() {
+    return canAddChildren;
+  }
+
+  public void setCanAddChildren( boolean canAddChildren ) {
+    this.canAddChildren = canAddChildren;
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProvider.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProvider.java
@@ -1,0 +1,171 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.genericfile.providers.repository;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.pentaho.platform.api.genericfile.IGenericFileProvider;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileDto;
+import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileTreeDto;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.genericfile.messages.Messages;
+import org.pentaho.platform.genericfile.providers.repository.model.RepositoryFile;
+import org.pentaho.platform.genericfile.providers.repository.model.RepositoryFileTree;
+import org.pentaho.platform.genericfile.providers.repository.model.RepositoryFolder;
+import org.pentaho.platform.genericfile.providers.repository.model.RepositoryObject;
+import org.pentaho.platform.web.http.api.resources.services.FileService;
+
+import java.util.Date;
+
+import static org.pentaho.platform.util.RepositoryPathEncoder.encodeRepositoryPath;
+
+public class RepositoryFileProvider implements IGenericFileProvider<RepositoryFile> {
+  public static String REPOSITORY_PREFIX = "/";
+  private IUnifiedRepository unifiedRepository;
+
+  @Override public Class<RepositoryFile> getFileClass() {
+    return RepositoryFile.class;
+  }
+
+  private RepositoryFileTree tree;
+  public static final String TYPE = "repository";
+
+  public RepositoryFileProvider() {
+    unifiedRepository = PentahoSystem.get( IUnifiedRepository.class, PentahoSessionHolder.getSession() );
+  }
+
+  @Override
+  public String getName() {
+    return Messages.getString( "GenericFileRepository.REPOSITORY_FOLDER_DISPLAY" );
+  }
+
+  @Override
+  public String getType() {
+    return TYPE;
+  }
+
+  @Override
+  public boolean createFolder( String path ) {
+    try {
+      FileService fileService = new FileService();
+
+      boolean success = fileService.doCreateDirSafe( encodeRepositoryPath( path ) );
+      if ( success ) {
+        clearFolderCache();
+      }
+
+      return success;
+    } catch ( FileService.InvalidNameException e ) {
+      return false;
+    }
+  }
+
+  @Override
+  public RepositoryFileTree getFolders( Integer depth ) {
+    if ( tree != null ) {
+      return tree;
+    }
+
+    FileService fileService = new FileService();
+    RepositoryFileTreeDto nativeTree =
+      fileService.doGetTree( "/", depth, "*|FOLDERS", true, false, false );
+
+
+    tree = convertToTreeNode( nativeTree, null );
+
+    RepositoryFolder repositoryFolder = (RepositoryFolder) tree.getFile();
+    repositoryFolder.setName( Messages.getString( "GenericFileRepository.REPOSITORY_FOLDER_DISPLAY" ) );
+    repositoryFolder.setCanAddChildren( false );
+    repositoryFolder.setCanDelete( false );
+    repositoryFolder.setCanEdit( false );
+
+    return tree;
+  }
+
+  @Override
+  public void clearFolderCache() {
+    tree = null;
+  }
+
+  @Override
+  public boolean doesFolderExist( String path ) {
+    org.pentaho.platform.api.repository2.unified.RepositoryFile file = unifiedRepository.getFile( path );
+    return file != null;
+  }
+
+  private RepositoryObject convert(
+    @NonNull RepositoryFileDto nativeFile,
+    @Nullable RepositoryFolder parentRepositoryFolder ) {
+
+    RepositoryObject repositoryObject = nativeFile.isFolder() ? new RepositoryFolder() : new RepositoryFile();
+
+    repositoryObject.setPath( nativeFile.getPath() );
+    repositoryObject.setName( nativeFile.getName() );
+    repositoryObject.setParent( parentRepositoryFolder != null ? parentRepositoryFolder.getPath() : null );
+    repositoryObject.setHidden( nativeFile.isHidden() );
+    Date modifiedDate = ( nativeFile.getLastModifiedDate() != null && !nativeFile.getLastModifiedDate().isEmpty() )
+        ? new Date( Long.parseLong( nativeFile.getLastModifiedDate() ) )
+        : new Date( Long.parseLong( nativeFile.getCreatedDate() ) );
+    repositoryObject.setModifiedDate( modifiedDate );
+    repositoryObject.setObjectId( nativeFile.getId().toString() );
+    repositoryObject.setCanEdit( true );
+    repositoryObject.setTitle( nativeFile.getTitle() );
+    repositoryObject.setDescription( nativeFile.getDescription() );
+    if ( nativeFile.isFolder() ) {
+      convertFolder( (RepositoryFolder) repositoryObject, nativeFile );
+    }
+
+    return repositoryObject;
+  }
+
+  private void convertFolder( @NonNull RepositoryFolder folder,
+                              RepositoryFileDto nativeFile ) {
+    folder.setCanAddChildren( true );
+  }
+
+  @NonNull
+  private RepositoryFileTree convertToTreeNode(
+    @NonNull RepositoryFileTreeDto nativeTree,
+    @Nullable RepositoryFolder parentRepositoryFolder ) {
+
+    RepositoryObject repositoryObject = convert( nativeTree.getFile(), parentRepositoryFolder );
+    RepositoryFileTree repositoryTree = new RepositoryFileTree( repositoryObject );
+    if ( nativeTree.getChildren() != null ) {
+      for ( RepositoryFileTreeDto nativeChildTree : nativeTree.getChildren() ) {
+        repositoryTree.addChild( convertToTreeNode( nativeChildTree, (RepositoryFolder) repositoryObject ) );
+      }
+    }
+
+    return repositoryTree;
+  }
+
+  @Override
+  public boolean isAvailable() {
+    return unifiedRepository != null;
+  }
+
+  @Override
+  public boolean owns( String path ) {
+    return path.startsWith( REPOSITORY_PREFIX );
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/genericfile/providers/repository/model/RepositoryFile.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/providers/repository/model/RepositoryFile.java
@@ -1,0 +1,63 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.genericfile.providers.repository.model;
+
+import org.pentaho.platform.api.genericfile.model.IGenericFile;
+
+import java.util.Objects;
+
+public class RepositoryFile extends RepositoryObject implements IGenericFile {
+
+  private String username;
+
+  public RepositoryFile() {
+    // Necessary for JSON marshalling
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername( String username ) {
+    this.username = username;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash( getProvider(), getPath() );
+  }
+
+  @Override
+  public boolean equals( Object obj ) {
+    // If the object is compared with itself then return true
+    if ( obj == this ) {
+      return true;
+    }
+
+    if ( !( obj instanceof RepositoryFile ) ) {
+      return false;
+    }
+
+    RepositoryFile compare = (RepositoryFile) obj;
+    return compare.getProvider().equals( getProvider() )
+      && ( ( compare.getPath() == null && getPath() == null ) || compare.getPath().equals( getPath() ) );
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/genericfile/providers/repository/model/RepositoryFileTree.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/providers/repository/model/RepositoryFileTree.java
@@ -1,0 +1,36 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.genericfile.providers.repository.model;
+
+import org.pentaho.platform.genericfile.model.BaseGenericFileTree;
+import org.pentaho.platform.genericfile.providers.repository.RepositoryFileProvider;
+
+public class RepositoryFileTree extends BaseGenericFileTree {
+
+  public RepositoryFileTree( RepositoryObject file ) {
+    super( file );
+  }
+
+  @Override
+  public String getProvider() {
+    return RepositoryFileProvider.TYPE;
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/genericfile/providers/repository/model/RepositoryFolder.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/providers/repository/model/RepositoryFolder.java
@@ -1,0 +1,50 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.genericfile.providers.repository.model;
+
+import org.pentaho.platform.api.genericfile.model.IGenericFolder;
+
+public class RepositoryFolder extends RepositoryFile implements IGenericFolder {
+  private boolean canAddChildren;
+  private boolean hasChildren;
+
+  public RepositoryFolder() {
+    this.setType( TYPE_FOLDER );
+    this.setHasChildren( true );
+  }
+
+  @Override
+  public boolean isCanAddChildren() {
+    return canAddChildren;
+  }
+
+  public void setCanAddChildren( boolean canAddChildren ) {
+    this.canAddChildren = canAddChildren;
+  }
+
+  public boolean isHasChildren() {
+    return hasChildren;
+  }
+
+  public void setHasChildren( boolean hasChildren ) {
+    this.hasChildren = hasChildren;
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/genericfile/providers/repository/model/RepositoryObject.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/providers/repository/model/RepositoryObject.java
@@ -1,0 +1,69 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.genericfile.providers.repository.model;
+
+import org.pentaho.platform.api.genericfile.model.IGenericFile;
+import org.pentaho.platform.genericfile.model.BaseGenericFile;
+import org.pentaho.platform.genericfile.providers.repository.RepositoryFileProvider;
+
+public abstract class RepositoryObject extends BaseGenericFile implements IGenericFile {
+  private String objectId;
+  private String extension;
+  private String repository;
+  private boolean hidden;
+
+  @Override
+  public String getProvider() {
+    return RepositoryFileProvider.TYPE;
+  }
+
+  public String getObjectId() {
+    return objectId;
+  }
+
+  public void setObjectId( String objectId ) {
+    this.objectId = objectId;
+  }
+
+  public String getExtension() {
+    return extension;
+  }
+
+  public void setExtension( String extension ) {
+    this.extension = extension;
+  }
+
+  public String getRepository() {
+    return repository;
+  }
+
+  public void setRepository( String repository ) {
+    this.repository = repository;
+  }
+
+  public boolean isHidden() {
+    return hidden;
+  }
+
+  public void setHidden( boolean hidden ) {
+    this.hidden = hidden;
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/EmbeddedQuartzSystemListener.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/EmbeddedQuartzSystemListener.java
@@ -54,7 +54,7 @@ public class EmbeddedQuartzSystemListener implements IPluginLifecycleListener {
   /*
    * This is re-use by Copy and Paste to avoid a dependency on the bi-platform-scheduler project (which will eventually
    * be phased out).
-   * 
+   *
    * The only difference between this and the other class is that this system listener will initialize the quartz
    * database if it hasn't been created yet.
    */
@@ -264,7 +264,7 @@ public class EmbeddedQuartzSystemListener implements IPluginLifecycleListener {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see org.pentaho.core.system.IPentahoSystemListener#shutdown()
    */
   public void shutdown() {

--- a/core/src/main/java/org/pentaho/platform/web/http/api/resources/GenericFileResource.java
+++ b/core/src/main/java/org/pentaho/platform/web/http/api/resources/GenericFileResource.java
@@ -1,0 +1,120 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2023 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.web.http.api.resources;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.codehaus.enunciate.jaxrs.ResponseCode;
+import org.codehaus.enunciate.jaxrs.StatusCodes;
+import org.pentaho.platform.api.genericfile.IGenericFileService;
+import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Objects;
+
+@Path( "/scheduler-plugin/api/generic-files" )
+public class GenericFileResource {
+
+  private final IGenericFileService genericFileService;
+
+  public GenericFileResource( @NonNull IGenericFileService genericFileService ) {
+    Objects.requireNonNull( genericFileService );
+    this.genericFileService = genericFileService;
+  }
+
+  @GET
+  @Path( "/folders/tree" )
+  @Produces( { MediaType.APPLICATION_JSON } )
+  public Response loadFolderTree( @QueryParam( "depth" ) Integer depth ) {
+    IGenericFileTree tree = genericFileService.getFolders( depth );
+    return Response.ok( tree ).build();
+  }
+
+  @DELETE
+  @Path( "/folders/tree/cache" )
+  @StatusCodes( {
+    @ResponseCode( code = 204, condition = "Cache was cleared successfully" ),
+    @ResponseCode( code = 401, condition = "Authentication required" ),
+    @ResponseCode( code = 403, condition = "Access forbidden" ),
+    @ResponseCode( code = 500, condition = "Internal Server Error" )
+  } )
+  public Response clearCache() {
+    try {
+      genericFileService.clearFolderCache();
+      return Response.status( Response.Status.NO_CONTENT ).build();
+    } catch ( Exception e ) {
+      return Response.status( Response.Status.INTERNAL_SERVER_ERROR ).build();
+    }
+  }
+
+  @HEAD
+  @Path( "/folders/{path : .+}" )
+  @StatusCodes( {
+    @ResponseCode( code = 204, condition = "Folder exists" ),
+    @ResponseCode( code = 401, condition = "Authentication required" ),
+    @ResponseCode( code = 404, condition = "Folder does not exist" ) } )
+  public void doesFolderExist( @PathParam( "path" ) String path ) {
+    try {
+      if ( !genericFileService.doesFolderExist( decodePath( path ) ) ) {
+        throw new WebApplicationException( Response.Status.NOT_FOUND );
+      }
+    } catch ( Exception e ) {
+      throw new WebApplicationException( e, Response.Status.INTERNAL_SERVER_ERROR );
+    }
+  }
+
+  @POST
+  @Path( "/folders/{path : .+}" )
+  @StatusCodes( {
+    @ResponseCode( code = 201, condition = "Folder creation succeeded." ),
+    @ResponseCode( code = 401, condition = "Authentication required" ),
+    @ResponseCode( code = 403, condition = "Access forbidden" ),
+    @ResponseCode( code = 409, condition = "Folder creation failed; folder already exists" ),
+    @ResponseCode( code = 500, condition = "Folder creation failed" )
+  } )
+  public Response createFolder( @PathParam( "path" ) String path ) {
+
+    // TODO: actually implement the error codes
+
+    try {
+      if ( genericFileService.createFolder( decodePath( path ) ) ) {
+        return Response.status( Response.Status.CREATED ).build();
+      }
+
+      throw new WebApplicationException( Response.Status.INTERNAL_SERVER_ERROR );
+    } catch ( Exception e ) {
+      throw new WebApplicationException( e, Response.Status.INTERNAL_SERVER_ERROR );
+    }
+  }
+
+  public String decodePath( String path ) {
+    return path.replace( ":", "/" ).replace( "~", ":" );
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/web/http/api/resources/SchedulerOutputPathResolver.java
+++ b/core/src/main/java/org/pentaho/platform/web/http/api/resources/SchedulerOutputPathResolver.java
@@ -14,19 +14,19 @@
  * See the GNU Lesser General Public License for more details.
  *
  *
- * Copyright (c) 2002-2018 Hitachi Vantara. All rights reserved.
- *
+ * Copyright (c) 2002-2023 Hitachi Vantara. All rights reserved.
  */
 
 package org.pentaho.platform.web.http.api.resources;
 
+import com.google.common.annotations.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.platform.api.engine.IPentahoSession;
-import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
-import org.pentaho.platform.api.repository2.unified.RepositoryFile;
-import org.pentaho.platform.api.scheduler2.IJobScheduleRequest;
+import org.pentaho.platform.api.genericfile.IGenericFileService;
 import org.pentaho.platform.api.usersettings.IUserSettingService;
 import org.pentaho.platform.api.usersettings.pojo.IUserSetting;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
@@ -43,8 +43,15 @@ public class SchedulerOutputPathResolver {
 
   private static final Log logger = LogFactory.getLog( SchedulerOutputPathResolver.class );
 
-  private IUnifiedRepository repository = PentahoSystem.get( IUnifiedRepository.class );
+  private IGenericFileService genericFileService;
   private IPentahoSession pentahoSession = PentahoSessionHolder.getSession();
+
+  private IUserSettingService settingsService;
+  private JobScheduleRequest scheduleRequest;
+
+  public SchedulerOutputPathResolver( JobScheduleRequest scheduleRequest ) {
+    this.scheduleRequest = scheduleRequest;
+  }
 
   private IUserSettingService getSettingsService() {
     if ( settingsService == null ) {
@@ -53,11 +60,18 @@ public class SchedulerOutputPathResolver {
     return settingsService;
   }
 
-  private IUserSettingService settingsService;
-  private JobScheduleRequest scheduleRequest;
+  @NonNull
+  private IGenericFileService getGenericFileService() {
+    if ( genericFileService == null ) {
+      genericFileService = PentahoSystem.get( IGenericFileService.class, pentahoSession );
+    }
 
-  public SchedulerOutputPathResolver( JobScheduleRequest scheduleRequest ) {
-    this.scheduleRequest = scheduleRequest;
+    return genericFileService;
+  }
+
+  @VisibleForTesting
+  void setGenericFileService( @Nullable IGenericFileService genericFileService ) {
+    this.genericFileService = genericFileService;
   }
 
   public String resolveOutputFilePath() {
@@ -70,7 +84,8 @@ public class SchedulerOutputPathResolver {
 
     String outputFilePath = scheduleRequest.getOutputFile();
     if ( outputFilePath != null && outputFilePath.endsWith( fileNamePattern ) ) {
-      // we are creating a schedule with a completed path already, strip off the pattern and validate the folder is valid
+      // we are creating a schedule with a completed path already, strip off the pattern and validate the folder is
+      // valid
       outputFilePath = outputFilePath.substring( 0, outputFilePath.indexOf( fileNamePattern ) );
     }
     if ( StringUtils.isNotBlank( outputFilePath ) && isValidOutputPath( outputFilePath ) ) {
@@ -94,13 +109,11 @@ public class SchedulerOutputPathResolver {
 
   protected boolean isValidOutputPath( String path ) {
     try {
-      RepositoryFile repoFile = repository.getFile( path );
-      if ( repoFile != null && repoFile.isFolder() ) {
-        return true;
-      }
+      return getGenericFileService().doesFolderExist( path );
     } catch ( Exception e ) {
       logger.warn( e.getMessage(), e );
     }
+
     return false;
   }
 

--- a/core/src/main/resources/org/pentaho/platform/genericfile/messages/messages.properties
+++ b/core/src/main/resources/org/pentaho/platform/genericfile/messages/messages.properties
@@ -1,0 +1,1 @@
+GenericFileRepository.REPOSITORY_FOLDER_DISPLAY=Repository

--- a/core/src/main/resources/org/pentaho/platform/genericfile/messages/messages_en.properties
+++ b/core/src/main/resources/org/pentaho/platform/genericfile/messages/messages_en.properties
@@ -1,0 +1,1 @@
+GenericFileRepository.REPOSITORY_FOLDER_DISPLAY=Repository

--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,25 @@
     <mockito-core.version>4.0.0</mockito-core.version>
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
     <hamcrest-core.version>1.3</hamcrest-core.version>
+    <pentaho-scheduler-plugin.version>10.1.0.0-SNAPSHOT</pentaho-scheduler-plugin.version>
+    <com.github.spotbugs.annotations.version>4.2.3</com.github.spotbugs.annotations.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-annotations</artifactId>
+        <version>${com.github.spotbugs.annotations.version}</version>
+        <scope>provided</scope>
+        <optional>true</optional>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <modules>
       <module>core</module>
       <module>ui</module>
       <module>assembly</module>
+      <module>api</module>
   </modules>
 </project>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -86,6 +86,10 @@
             <artifactId>jsinterop-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.gwt.gwtmockito</groupId>
             <artifactId>gwtmockito</artifactId>
             <version>${gwtmockito.version}</version>

--- a/ui/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/NewScheduleDialog.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/NewScheduleDialog.java
@@ -209,7 +209,6 @@ public class NewScheduleDialog extends PromptDialogBox {
         }
 
         public void cancelPressed() {
-          selectFolder.cancelSelection();
         }
       } );
 

--- a/ui/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEmailDialog.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEmailDialog.java
@@ -86,7 +86,7 @@ public class ScheduleEmailDialog extends AbstractWizardDialog {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see org.pentaho.gwt.widgets.client.wizards.AbstractWizardDialog#finish()
    */
   @Override
@@ -115,7 +115,7 @@ public class ScheduleEmailDialog extends AbstractWizardDialog {
       scheduleParams.set( scheduleParams.size(), new JSONObject( p ) );
     }
 
-    scheduleRequest.put( "jobParameters", scheduleParams ); //$NON-NLS-1$    
+    scheduleRequest.put( "jobParameters", scheduleParams ); //$NON-NLS-1$
 
     RequestBuilder scheduleFileRequestBuilder = ScheduleHelper.buildRequestForJob( editJob, scheduleRequest );
 
@@ -168,7 +168,7 @@ public class ScheduleEmailDialog extends AbstractWizardDialog {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see
    * org.pentaho.gwt.widgets.client.wizards.AbstractWizardDialog#onNext(org.pentaho.gwt.widgets.client.wizards.
    * IWizardPanel, org.pentaho.gwt.widgets.client.wizards.IWizardPanel)
@@ -181,7 +181,7 @@ public class ScheduleEmailDialog extends AbstractWizardDialog {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see
    * org.pentaho.gwt.widgets.client.wizards.AbstractWizardDialog#onPrevious(org.pentaho.gwt.widgets.client.wizards
    * .IWizardPanel, org.pentaho.gwt.widgets.client.wizards.IWizardPanel)

--- a/ui/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleOutputLocationDialog.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleOutputLocationDialog.java
@@ -168,7 +168,6 @@ public abstract class ScheduleOutputLocationDialog extends PromptDialogBox {
         }
 
         public void cancelPressed() {
-          selectFolder.cancelSelection();
         }
       } );
 

--- a/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPanel.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPanel.java
@@ -1153,7 +1153,22 @@ public class SchedulesPanel extends SimplePanel {
     setBrowserPerspective();
     String url = EnvironmentHelper.getFullyQualifiedURL() + "api/mantle/session-variable?key=scheduler_folder&value=" + outputLocation;
     RequestBuilder executableTypesRequestBuilder = new CsrfRequestBuilder( RequestBuilder.POST, url );
-    sendRequest(executableTypesRequestBuilder);
+    try {
+      executableTypesRequestBuilder.sendRequest( null, new RequestCallback() {
+        @Override
+        public void onResponseReceived( Request request, Response response ) {
+          // fire and forget
+        }
+
+        @Override
+        public void onError( Request request, Throwable exception ) {
+          // fire and forget
+        }
+      } );
+    } catch ( RequestException e ) {
+      // IGNORE
+    }
+
     fireRefreshFolderEvent( outputLocation );
   }
 
@@ -1243,10 +1258,6 @@ public class SchedulesPanel extends SimplePanel {
 
   public native void setBrowserPerspective() /*-{
    $wnd.mantle.setBrowserPerspective();
-  }-*/;
-
-  public native void sendRequest( RequestBuilder executableTypesRequestBuilder ) /*-{
-   $wnd.mantle.sendRequest(executableTypesRequestBuilder);
   }-*/;
 
   public native void fireRefreshFolderEvent( String outputLocation ) /*-{


### PR DESCRIPTION
Introduces a new FS abstraction that unifies the Repository and the VFS file systems, allowing these to be consumed seamlessly by the scheduler, as well as by dialogs such as the Select Folder dialog. The code is derived from similar PDI code.

Part of PR set: https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/68


Co-authored by: @soagarwal1, @rmansoor and me (also added to commit message as described in [github docs](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors)).

@pentaho/hoth, @pentaho/r2d2, @pentaho/millenniumfalcon, please review at your will.