### PR TITLE
[BACKLOG-37877] Scheduler perspective only shows hyperlink to repo output locations

### DIFF
--- a/ui/src/main/java/org/pentaho/mantle/client/workspace/JsJob.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/workspace/JsJob.java
@@ -21,6 +21,8 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.DateTimeFormat.PredefinedFormat;
+import org.pentaho.gwt.widgets.client.genericfile.GenericFileNameUtils;
+
 import java.util.Date;
 
 public class JsJob extends JavaScriptObject {
@@ -114,9 +116,22 @@ public class JsJob extends JavaScriptObject {
     if ( resource == null || "".equals( resource ) ) {
       return "";
     }
-    resource = resource.substring( resource.indexOf( ":" ) );
-    resource = resource.substring( resource.indexOf( "/" ), resource.lastIndexOf( "/" ) );
-    return resource;
+
+    // Sample values
+    // "input file = /home/admin/report.prpt:outputFile = pvfs://MyS3/folder/report.*"
+    // "input file = /home/admin/report.prpt:outputFile = /home/admin/folder/report.*"
+
+    // Extract outputFile value.
+    String token = "outputFile = ";
+    int index = resource.indexOf( token );
+    if ( index < 0 ) {
+      return "";
+    }
+
+    resource = resource.substring( index + token.length() );
+
+    // Remove file name pattern in last segment, to get the output folder.
+    return GenericFileNameUtils.getParentPath( resource );
   }
 
   public final void setOutputPath( String outputPath, String outputFileName ) {

--- a/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPanel.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPanel.java
@@ -60,6 +60,7 @@ import com.google.gwt.view.client.SelectionChangeEvent.Handler;
 import org.apache.http.protocol.HTTP;
 import org.pentaho.gwt.widgets.client.dialogs.IDialogCallback;
 import org.pentaho.gwt.widgets.client.dialogs.MessageDialogBox;
+import org.pentaho.gwt.widgets.client.genericfile.GenericFileNameUtils;
 import org.pentaho.gwt.widgets.client.toolbar.Toolbar;
 import org.pentaho.gwt.widgets.client.toolbar.ToolbarButton;
 import org.pentaho.gwt.widgets.client.utils.NameUtils;
@@ -389,6 +390,10 @@ public class SchedulesPanel extends SimplePanel {
           String outputPath = jsJob.getOutputPath();
           if ( StringUtils.isEmpty( outputPath ) ) {
             return BLANK_VALUE;
+          }
+
+          if ( !GenericFileNameUtils.isRepositoryPath( outputPath ) ) {
+            return outputPath;
           }
 
           outputPath = new SafeHtmlBuilder().appendEscaped( outputPath ).toSafeHtml().asString();


### PR DESCRIPTION
- Also, changes `JsJob.getOutputPath()` to account for the new syntax of generic file paths

JIRA issue: https://hv-eng.atlassian.net/browse/BACKLOG-37877

Merge along with:
- https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1003

@pentaho/hoth, please, review.