### PR TITLE
[BACKLOG-39834] Schedule - Incorrect automatic update of output file …

### DIFF
--- a/core/src/main/java/org/pentaho/platform/scheduler2/action/SchedulerFilenameUtils.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/action/SchedulerFilenameUtils.java
@@ -1,0 +1,99 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2024 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.scheduler2.action;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * General filename and filepath manipulation utilities. Primarily to support Pentaho Repository and URI file paths.
+ * Similar logic to {@link org.pentaho.platform.repository.RepositoryFilenameUtils}
+ * and {@link org.apache.commons.io.FilenameUtils }
+ *
+ */
+public class SchedulerFilenameUtils {
+
+  /**
+   * Hiding default constructor this is a utility class.
+   */
+  private SchedulerFilenameUtils() {
+    // EMPTY ON PURPOSE
+  }
+
+  /**
+   * Separator for file paths. Assuming unix style separator due pentaho domain.
+   */
+  protected static final String PATH_SEPARATOR = "/";
+
+  /**
+   * Combine <code>basePath</code> and <code>pathToAdd</code> using path separator defined by {@link #PATH_SEPARATOR}.
+   * <p/>
+   *
+   * Examples:
+   * <p/>
+   * <pre>
+   * /foo + bar                  -->   /foo/bar
+   * /foo/ + bar                 -->   /foo/bar
+   * /foo + /bar                 -->   /foo/bar
+   * /foo/ + /bar                -->   /foo/bar
+   * /foo + bar.txt              -->   /foo/bar.txt
+   * /foo/ + bar.txt             -->   /foo/bar.txt
+   * /foo + /bar.txt             -->   /foo/bar.txt
+   * /foo/ + /bar.txt            -->   /foo/bar.txt
+   * scheme://foo + bar          -->   scheme://foo/bar
+   * scheme://foo/ + bar         -->   scheme://foo/bar
+   * scheme://foo + /bar         -->   scheme://foo/bar
+   * scheme://foo/ + /bar        -->   scheme://foo/bar
+   * scheme://foo + bar.txt      -->   scheme://foo/bar.txt
+   * scheme://foo/ + bar.txt     -->   scheme://foo/bar.txt
+   * scheme://foo + /bar.txt     -->   scheme://foo/bar.txt
+   * scheme://foo/ + /bar.txt    -->   scheme://foo/bar.txt
+   * </pre>
+   *
+   * @param basePath
+   * @param pathToAdd
+   * @return combined path consisting of: <code>basePath</code> + {@value #PATH_SEPARATOR} + <code>pathToAdd</code>
+   */
+  public static String concat( String basePath, String pathToAdd ) {
+
+    if ( basePath == null || pathToAdd == null ) {
+      return null;
+    }
+    /*
+     * NOTE don't alter schema syntax ie remove // in a URI.
+     * Don't call any function that eventually calls org.apache.commons.io.FilenameUtils#normalize
+     * Similar logic to org.pentaho.platform.web.http.api.resources.SchedulerOutputPathResolver
+     */
+    return getNoEndSeparator( basePath )  + PATH_SEPARATOR + FilenameUtils.getName( pathToAdd );
+  }
+
+  /**
+   * Return only the path without the ending separator defined by {@link #PATH_SEPARATOR}
+   * @param path
+   * @return <code>path</code> without the end separator
+   */
+  protected static String getNoEndSeparator( String path ) {
+    return  ( StringUtils.isNotBlank( path )
+        && path.length() - 1 == FilenameUtils.indexOfLastSeparator( path ) )
+      ? path.substring( 0, path.length() - 1 ) // remove end separator
+      : path;
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/scheduler2/action/SchedulerOutputPathResolver.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/action/SchedulerOutputPathResolver.java
@@ -20,13 +20,6 @@
 
 package org.pentaho.platform.scheduler2.action;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Callable;
-
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
@@ -44,9 +37,15 @@ import org.pentaho.platform.api.usersettings.pojo.IUserSetting;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.security.SecurityHelper;
-import org.pentaho.platform.repository.RepositoryFilenameUtils;
 import org.pentaho.platform.scheduler2.ISchedulerOutputPathResolver;
 import org.pentaho.platform.scheduler2.messsages.Messages;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
 
 /**
  * @author Rowell Belen
@@ -136,12 +135,13 @@ public class SchedulerOutputPathResolver implements ISchedulerOutputPathResolver
 
   /**
    * Combine <code>directory</code> and <code>filename</code>
+   *
    * @param directory
    * @param filename
    * @return
    */
   public String concat( String directory, String filename ) {
-    return RepositoryFilenameUtils.concat( directory, filename );
+    return SchedulerFilenameUtils.concat( directory, filename );
   }
 
   private String runAsUser( Callable<String> callable ) {

--- a/core/src/test/java/org/pentaho/platform/scheduler2/action/SchedulerFilenameUtilsTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/action/SchedulerFilenameUtilsTest.java
@@ -1,0 +1,158 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2024 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.scheduler2.action;
+
+import junit.framework.TestCase;
+
+public class SchedulerFilenameUtilsTest extends TestCase {
+
+
+  public void testConcat_Repository() {
+
+    // TEST null arguments
+    assertNull( SchedulerFilenameUtils.concat( null,
+        "/simple_report_name8.prpt" )
+    );
+
+    assertNull( SchedulerFilenameUtils.concat( "/home/randomUser",
+        null )
+    );
+
+    assertNull( SchedulerFilenameUtils.concat( null,
+      null )
+    );
+
+    // TEST - basePath and pathToAdd BOTH DON'T have separator
+    assertEquals( "/home/randomUser/simple_report_name8.prpt",
+      SchedulerFilenameUtils.concat( "/home/randomUser/",
+        "simple_report_name8.prpt" )
+    );
+
+    assertEquals( "/home/randomUser/afolder",
+      SchedulerFilenameUtils.concat( "/home/randomUser/",
+        "afolder" )
+    );
+
+    // TEST - basePath has end separator
+    assertEquals( "/home/randomUser/simple_report_name8.prpt",
+      SchedulerFilenameUtils.concat( "/home/randomUser/",
+        "simple_report_name8.prpt" )
+    );
+
+    assertEquals( "/home/randomUser/afolder",
+      SchedulerFilenameUtils.concat( "/home/randomUser/",
+        "afolder" )
+    );
+
+    // TEST - pathToAdd has end separator
+    assertEquals( "/home/randomUser/simple_report_name8.prpt",
+      SchedulerFilenameUtils.concat( "/home/randomUser",
+        "/simple_report_name8.prpt" )
+    );
+
+    assertEquals( "/home/randomUser/afolder",
+      SchedulerFilenameUtils.concat( "/home/randomUser",
+        "/afolder" )
+    );
+
+    // TEST - basePath and pathToAdd BOTH have separator
+    assertEquals( "/home/randomUser/simple_report_name8.prpt",
+      SchedulerFilenameUtils.concat( "/home/randomUser",
+        "/simple_report_name8.prpt" )
+    );
+
+    assertEquals( "/home/randomUser/afolder",
+      SchedulerFilenameUtils.concat( "/home/randomUser",
+        "/afolder" )
+    );
+  }
+
+  public void testConcat_Scheme() {
+
+    // TEST null arguments
+    assertNull( SchedulerFilenameUtils.concat( null,
+        "simple_file_name.pdf" )
+    );
+
+    assertNull( SchedulerFilenameUtils.concat( "ascheme://somBucket/someFolder/simple_file_name.pdf",
+      null )
+    );
+
+    assertNull( SchedulerFilenameUtils.concat( null,
+      null )
+    );
+
+    // TEST - basePath and pathToAdd BOTH DON'T have separator
+    assertEquals( "ascheme://somBucket/someFolder/simple_file_name.pdf",
+      SchedulerFilenameUtils.concat( "ascheme://somBucket/someFolder",
+        "simple_file_name.pdf" )
+    );
+
+    assertEquals( "ascheme://somBucket/someFolder/mysteryFolder",
+      SchedulerFilenameUtils.concat( "ascheme://somBucket/someFolder",
+        "mysteryFolder" )
+    );
+
+    // TEST - basePath has end separator
+    assertEquals( "ascheme://somBucket/someFolder/simple_file_name.pdf",
+      SchedulerFilenameUtils.concat( "ascheme://somBucket/someFolder/",
+        "simple_file_name.pdf" )
+    );
+
+    assertEquals( "ascheme://somBucket/someFolder/mysteryFolder",
+      SchedulerFilenameUtils.concat( "ascheme://somBucket/someFolder/",
+        "mysteryFolder" )
+    );
+
+    // TEST - pathToAdd has end separator
+    assertEquals( "ascheme://somBucket/someFolder/simple_file_name.pdf",
+      SchedulerFilenameUtils.concat( "ascheme://somBucket/someFolder",
+        "/simple_file_name.pdf" )
+    );
+
+    assertEquals( "ascheme://somBucket/someFolder/mysteryFolder",
+      SchedulerFilenameUtils.concat( "ascheme://somBucket/someFolder/",
+        "/mysteryFolder" )
+    );
+
+    // TEST - basePath and pathToAdd BOTH have separator
+    assertEquals( "ascheme://somBucket/someFolder/simple_file_name.pdf",
+      SchedulerFilenameUtils.concat( "ascheme://somBucket/someFolder",
+        "simple_file_name.pdf" )
+    );
+
+    assertEquals( "ascheme://somBucket/someFolder/mysteryFolder",
+      SchedulerFilenameUtils.concat( "ascheme://somBucket/someFolder/",
+        "/mysteryFolder" )
+    );
+  }
+
+  public void testGetNoEndSeparator() {
+    assertNull( SchedulerFilenameUtils.getNoEndSeparator( null ) );
+    assertEquals( "", SchedulerFilenameUtils.getNoEndSeparator( "" ) );
+    assertEquals( "", SchedulerFilenameUtils.getNoEndSeparator( "/" ) );
+    assertEquals( "/foo", SchedulerFilenameUtils.getNoEndSeparator( "/foo" ) );
+    assertEquals( "/bar", SchedulerFilenameUtils.getNoEndSeparator( "/bar/" ) );
+    assertEquals( "/a/b/c", SchedulerFilenameUtils.getNoEndSeparator( "/a/b/c/" ) );
+    assertEquals( "/a/b/c/d", SchedulerFilenameUtils.getNoEndSeparator( "/a/b/c/d" ) );
+    assertEquals( "/a/bee/c/duck", SchedulerFilenameUtils.getNoEndSeparator( "/a/bee/c/duck" ) );
+  }
+}

--- a/core/src/test/java/org/pentaho/platform/scheduler2/action/SchedulerOutputPathResolverTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/action/SchedulerOutputPathResolverTest.java
@@ -1,0 +1,50 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2024 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.scheduler2.action;
+
+import junit.framework.TestCase;
+
+public class SchedulerOutputPathResolverTest extends TestCase {
+
+  public void testConcat() throws Exception {
+
+    SchedulerOutputPathResolver testInstance = new SchedulerOutputPathResolver( );
+
+    // TEST 1 - directory path does not have separator
+    assertNotNull( testInstance );
+
+    String argDirectoryNoEndSeparator = "/home/admin";
+    String argFilename2 = "simple_report_name2.prpt";
+    String expectedFullPathRepoHomeAdmdin = "/home/admin/simple_report_name2.prpt";
+
+    String actualFullPath1 = testInstance.concat( argDirectoryNoEndSeparator, argFilename2 );
+    assertEquals( expectedFullPathRepoHomeAdmdin, actualFullPath1 );
+
+    // TEST 2 - directory path does not have separator
+    String argDirectoryWithSeparator = "/public/";
+    String argFilename3 = "simple_report_name3.prpt";
+    String expectedFullPathRepoHome = "/public/simple_report_name3.prpt";
+
+    String actualFullPath2 = testInstance.concat( argDirectoryWithSeparator, argFilename3 );
+    assertEquals( expectedFullPathRepoHome, actualFullPath2 );
+  }
+
+}


### PR DESCRIPTION
…when suzy user execute a schedule

- handling both file paths with repository and uri formats

See analysis: https://hv-eng.atlassian.net/browse/BACKLOG-39834?focusedCommentId=1947768

PR Merge Dependencies
- https://github.com/pentaho/pentaho-scheduler-plugin/pull/101
  - **source code changes** and unit tests
- https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/163
  - _**not immediately necessary**, can wait till later_
  - test code only, but depends on source code change from above PR