### PR TITLE
[CLEANUP][TEST] Refactor JsJob and add unit tests

### DIFF
--- a/ui/src/test/java/org/pentaho/mantle/client/workspace/JsJobTest.java
+++ b/ui/src/test/java/org/pentaho/mantle/client/workspace/JsJobTest.java
@@ -65,4 +65,126 @@ public class JsJobTest {
     
     assertEquals( "/some_valid_value", resourceName );
   }
+
+  @Test
+  public void getScheduledExtn_basicPaths() {
+    doCallRealMethod().when( jsJob ).getScheduledExtn();
+
+    // Test jobs scheduled from PUC
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider-InputFile" ) )
+      .thenReturn( "/home/admin/myTransformation.ktr" );
+    assertEquals( "transformation", jsJob.getScheduledExtn() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider-InputFile" ) )
+      .thenReturn( "/home/admin/myJob.kjb" );
+    assertEquals( "job", jsJob.getScheduledExtn() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider-InputFile" ) )
+      .thenReturn( "/home/admin/myReport.prpt" );
+    assertEquals( "report", jsJob.getScheduledExtn() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider-InputFile" ) )
+      .thenReturn( "/home/admin/myReport2.prpti" );
+    assertEquals( "report", jsJob.getScheduledExtn() );
+
+    // Test jobs scheduled from Kettle
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider-InputFile" ) )
+      .thenReturn( null );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
+      .thenReturn( "input file = /home/admin/myTransformation.ktr:outputFile = /home/admin/myTransformation.*" );
+    assertEquals( "transformation", jsJob.getScheduledExtn() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
+      .thenReturn( "input file = /home/admin/myJob.kjb:outputFile = /home/admin/myJob.*" );
+    assertEquals( "job", jsJob.getScheduledExtn() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
+      .thenReturn( "input file = /home/admin/myReport.prpt:outputFile = /home/admin/myReport.*" );
+    assertEquals( "report", jsJob.getScheduledExtn() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
+      .thenReturn( "input file = /home/admin/myReport2.prpti:outputFile = /home/admin/myReport2.*" );
+    assertEquals( "report", jsJob.getScheduledExtn() );
+  }
+
+  @Test
+  public void getScheduledExtn_unusualPaths() {
+    doCallRealMethod().when( jsJob ).getScheduledExtn();
+
+    // Test jobs scheduled from PUC
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider-InputFile" ) )
+      .thenReturn( "/home/admin/with.dot:colon/myTransformation.ktr" );
+    assertEquals( "transformation", jsJob.getScheduledExtn() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider-InputFile" ) )
+      .thenReturn( "/home/admin/with.dot:colon/myJob.kjb" );
+    assertEquals( "job", jsJob.getScheduledExtn() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider-InputFile" ) )
+      .thenReturn( "/home/admin/with.dot:colon/myReport.prpt" );
+    assertEquals( "report", jsJob.getScheduledExtn() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider-InputFile" ) )
+      .thenReturn( "/home/admin/with.dot/myReport2.prpti" );
+    assertEquals( "report", jsJob.getScheduledExtn() );
+
+    // Test jobs scheduled from Kettle
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider-InputFile" ) )
+      .thenReturn( null );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
+      .thenReturn( "input file = /home/admin/with.dot:colon/myTransformation.ktr:outputFile = /home/admin/with.dot:colon/myTransformation.*" );
+    assertEquals( "transformation", jsJob.getScheduledExtn() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
+      .thenReturn( "input file = /home/admin/with.dot:colon/myJob.kjb:outputFile = /home/admin/with.dot:colon/myJob.*" );
+    assertEquals( "job", jsJob.getScheduledExtn() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
+      .thenReturn( "input file = /home/admin/with.dot:colon/myReport.prpt:outputFile = /home/admin/with.dot:colon/myReport.*" );
+    assertEquals( "report", jsJob.getScheduledExtn() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
+      .thenReturn( "input file = /home/admin/with.dot:colon/myReport2.prpti:outputFile = /home/admin/with.dot:colon/myReport2.*" );
+    assertEquals( "report", jsJob.getScheduledExtn() );
+  }
+
+  @Test
+  public void getScheduledExtn_invalidExtension() {
+    doCallRealMethod().when( jsJob ).getScheduledExtn();
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider-InputFile" ) )
+      .thenReturn( "/home/admin/wrong.txt" );
+    assertEquals( "-", jsJob.getScheduledExtn() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
+      .thenReturn( "input file = /home/admin/wrong.mp3:outputFile = /home/admin/wrong.*" );
+    assertEquals( "-", jsJob.getScheduledExtn() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider-InputFile" ) )
+      .thenReturn( "/home/admin/with.dot:colon/wrong.pdf" );
+    assertEquals( "-", jsJob.getScheduledExtn() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
+      .thenReturn( "input file = /home/admin/with.dot:colon/wrong.zip:outputFile = /home/admin/with.dot:colon/wrong.*" );
+    assertEquals( "-", jsJob.getScheduledExtn() );
+  }
+
+  @Test
+  public void getOutputPath() {
+    doCallRealMethod().when( jsJob ).getOutputPath();
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
+      .thenReturn( "input file = /home/admin/myTransformation.ktr:outputFile = /home/admin/myTransformation.*" );
+    assertEquals( "/home/admin", jsJob.getOutputPath() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
+      .thenReturn( "input file = /home/admin/with.dot:colon/myJob.kjb:outputFile = /home/admin/with.dot:colon/myJob.*" );
+    assertEquals( "/home/admin/with.dot:colon", jsJob.getOutputPath() );
+
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
+      .thenReturn( "input file = /home/admin/with.dot:colon=equals/myJob.kjb:outputFile = /home/admin/myJob.*" );
+    assertEquals( "/home/admin", jsJob.getOutputPath() );
+  }
 }


### PR DESCRIPTION
There are two small changes in behavior here:

- in `getScheduledExtn()`, we now fall through to `-` instead of `report` if the extension is unknown
- the parsing in `getOutputPath()` is a bit more robust and doesn't have issues with input paths that contain a `:` that comes before a `=`