### PR TITLE
[BACKLOG-39834] fixed problem with SchedulerFilenameUtils#concat only…

### DIFF
--- a/core/src/main/java/org/pentaho/platform/scheduler2/action/SchedulerFilenameUtils.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/action/SchedulerFilenameUtils.java
@@ -20,8 +20,7 @@
 
 package org.pentaho.platform.scheduler2.action;
 
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
+import org.pentaho.platform.web.http.api.resources.utils.FileUtils;
 
 /**
  * General filename and filepath manipulation utilities. Primarily to support Pentaho Repository and URI file paths.
@@ -39,50 +38,62 @@ public class SchedulerFilenameUtils {
   }
 
   /**
-   * Separator for file paths. Assuming unix style separator due pentaho domain.
+   * Windows style path separator.
    */
-  protected static final String PATH_SEPARATOR = "/";
+  protected static final String WINDOWS_PATH_SEPARATOR =  "\\";
+
+  /**
+   * Separator for file paths. Assuming unix style separator due to pentaho domain.
+   * The same value as {@link FileUtils#PATH_SEPARATOR}.
+   */
+  protected static final String PATH_SEPARATOR = FileUtils.PATH_SEPARATOR;
 
   /**
    * Combine <code>basePath</code> and <code>pathToAdd</code> using path separator defined by {@link #PATH_SEPARATOR}.
+   * Windows path separator, defined by {@link #WINDOWS_PATH_SEPARATOR}, is not supported.
    * <p/>
    *
    * Examples:
    * <p/>
    * <pre>
-   * /foo + bar                  -->   /foo/bar
-   * /foo/ + bar                 -->   /foo/bar
-   * /foo + /bar                 -->   /foo/bar
-   * /foo/ + /bar                -->   /foo/bar
-   * /foo + bar.txt              -->   /foo/bar.txt
-   * /foo/ + bar.txt             -->   /foo/bar.txt
-   * /foo + /bar.txt             -->   /foo/bar.txt
-   * /foo/ + /bar.txt            -->   /foo/bar.txt
-   * scheme://foo + bar          -->   scheme://foo/bar
-   * scheme://foo/ + bar         -->   scheme://foo/bar
-   * scheme://foo + /bar         -->   scheme://foo/bar
-   * scheme://foo/ + /bar        -->   scheme://foo/bar
-   * scheme://foo + bar.txt      -->   scheme://foo/bar.txt
-   * scheme://foo/ + bar.txt     -->   scheme://foo/bar.txt
-   * scheme://foo + /bar.txt     -->   scheme://foo/bar.txt
-   * scheme://foo/ + /bar.txt    -->   scheme://foo/bar.txt
+   * /foo + bar                       -->   /foo/bar
+   * /foo/ + bar                      -->   /foo/bar
+   * /foo + /bar                      -->   /foo/bar
+   * /foo/ + /bar                     -->   /foo/bar
+   * /foo + bar.txt                   -->   /foo/bar.txt
+   * /foo/ + bar.txt                  -->   /foo/bar.txt
+   * /foo + /bar.txt                  -->   /foo/bar.txt
+   * /foo/ + /bar.txt                 -->   /foo/bar.txt
+   * </pre>
+   * Same permutations for the following:
+   * <pre>
+   * scheme://foo/ + /bar.txt         -->   scheme://foo/bar.txt
+   * /foo/ + some/folder/path/bar.txt --> /foo/some/folder/path/bar.txt
    * </pre>
    *
    * @param basePath
    * @param pathToAdd
-   * @return combined path consisting of: <code>basePath</code> + {@value #PATH_SEPARATOR} + <code>pathToAdd</code>
+   * @return if both arguments are non-null then
+   * <p/> combined path consisting of: <code>basePath</code> + {@value #PATH_SEPARATOR} + <code>pathToAdd</code> <p/> , otherwise null.
+   * @throws IllegalArgumentException if path contains windows separator defined by {@link #WINDOWS_PATH_SEPARATOR}
    */
   public static String concat( String basePath, String pathToAdd ) {
 
     if ( basePath == null || pathToAdd == null ) {
       return null;
     }
+
+    checkPaths( basePath, pathToAdd );
+
     /*
      * NOTE don't alter schema syntax ie remove // in a URI.
      * Don't call any function that eventually calls org.apache.commons.io.FilenameUtils#normalize
      * Similar logic to org.pentaho.platform.web.http.api.resources.SchedulerOutputPathResolver
      */
-    return getNoEndSeparator( basePath )  + PATH_SEPARATOR + FilenameUtils.getName( pathToAdd );
+    return getNoEndSeparator( toSb( basePath ) )
+        .append( PATH_SEPARATOR )
+        .append( getNoEndSeparator( toSb( pathToAdd ).reverse() ).reverse() ) // remove separator at the start of path
+        .toString();
   }
 
   /**
@@ -90,10 +101,63 @@ public class SchedulerFilenameUtils {
    * @param path
    * @return <code>path</code> without the end separator
    */
-  protected static String getNoEndSeparator( String path ) {
-    return  ( StringUtils.isNotBlank( path )
-        && path.length() - 1 == FilenameUtils.indexOfLastSeparator( path ) )
-      ? path.substring( 0, path.length() - 1 ) // remove end separator
-      : path;
+  protected static StringBuilder getNoEndSeparator( StringBuilder path ) {
+    if ( path == null ) {
+      return null;
+    }
+
+    return ( indexOfLastSeparator( path ) != -1 && path.length() - 1 == indexOfLastSeparator( path )  )
+        ? path.deleteCharAt( path.length() - 1 ) // remove end separator
+        : path;
+  }
+
+  /**
+   * Return index of last separator defined by {@link #PATH_SEPARATOR}
+   * @param fileName
+   * @return 0th index of {@link #PATH_SEPARATOR}, -1 otherwise.
+   */
+  protected static int indexOfLastSeparator( StringBuilder fileName ) {
+    if ( fileName == null ) {
+      return -1;
+    } else {
+      return fileName.lastIndexOf( PATH_SEPARATOR );
+      /*
+       * NOTE: if we need to handle backward slash ie windows path separator
+       * see {@link org.apache.commons.io.FilenameUtils#indexOfLastSeparator}
+       */
+    }
+  }
+
+  /**
+   * Determines if all <code>paths</code> are valid.
+   * @param paths
+   * @throws IllegalArgumentException if a single path contains windows separator defined
+   * by {@link #WINDOWS_PATH_SEPARATOR}
+   */
+  protected static void checkPaths( String... paths ) {
+    for ( String path : paths ) {
+      checkPath( path );
+    }
+  }
+
+  /**
+   * Determines if <code>path</code> is valid.
+   * @param path
+   * @throws IllegalArgumentException if path contains windows separator defined by {@link #WINDOWS_PATH_SEPARATOR}
+   */
+  protected static void checkPath( String path ) {
+    if ( path.contains( WINDOWS_PATH_SEPARATOR ) ) {
+      throw new IllegalArgumentException(
+        "path with windows separator '" + WINDOWS_PATH_SEPARATOR + "' is not supported" );
+    }
+  }
+
+  /**
+   * Wrapper around instantiation of {@link StringBuilder}
+   * @param str
+   * @return
+   */
+  private static StringBuilder toSb( String str ) {
+    return new StringBuilder( str );
   }
 }

--- a/core/src/test/java/org/pentaho/platform/scheduler2/action/SchedulerFilenameUtilsTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/action/SchedulerFilenameUtilsTest.java
@@ -20,11 +20,14 @@
 
 package org.pentaho.platform.scheduler2.action;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class SchedulerFilenameUtilsTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
-
+public class SchedulerFilenameUtilsTest {
+  
+  @Test
   public void testConcat_Repository() {
 
     // TEST null arguments
@@ -83,8 +86,20 @@ public class SchedulerFilenameUtilsTest extends TestCase {
       SchedulerFilenameUtils.concat( "/home/randomUser",
         "/afolder" )
     );
+
+    // TEST pathToAdd is many folders + filename
+    assertEquals( "/home/randomUser/folderA/folderB/folderC/folderD/folderE/simple_file_name.pdf",
+      SchedulerFilenameUtils.concat( "/home/randomUser/folderA/folderB/",
+        "/folderC/folderD/folderE/simple_file_name.pdf" )
+    );
+
+    assertEquals( "/home/randomUser/folderA/folderB/folderC/folderD/folderE/folderF",
+      SchedulerFilenameUtils.concat( "/home/randomUser/folderA/folderB/",
+        "/folderC/folderD/folderE/folderF" )
+    );
   }
 
+  @Test
   public void testConcat_Scheme() {
 
     // TEST null arguments
@@ -143,16 +158,77 @@ public class SchedulerFilenameUtilsTest extends TestCase {
       SchedulerFilenameUtils.concat( "ascheme://somBucket/someFolder/",
         "/mysteryFolder" )
     );
+
+    // TEST pathToAdd is many folders + filename
+    assertEquals( "ascheme://somBucket/folderA/folderB/folderC/folderD/folderE/simple_file_name.pdf",
+      SchedulerFilenameUtils.concat( "ascheme://somBucket/folderA/folderB/",
+        "/folderC/folderD/folderE/simple_file_name.pdf" )
+    );
+
+    assertEquals( "ascheme://somBucket/folderA/folderB/folderC/folderD/folderE/folderF",
+      SchedulerFilenameUtils.concat( "ascheme://somBucket/folderA/folderB/",
+        "/folderC/folderD/folderE/folderF" )
+    );
   }
 
+  @Test( expected = IllegalArgumentException.class )
+  public void testConcat_exceptionThrown_windowsSeparator_basePath() {
+    SchedulerFilenameUtils.concat( "\\some\\windows\\folder\\", "aFile.txt" );
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  public void testConcat_exceptionThrown_windowsSeparator_pathToAdd() {
+    SchedulerFilenameUtils.concat( "/some/folder/", "\\windows\\relativePath\\aFile.txt" );
+  }
+
+  @Test
   public void testGetNoEndSeparator() {
-    assertNull( SchedulerFilenameUtils.getNoEndSeparator( null ) );
-    assertEquals( "", SchedulerFilenameUtils.getNoEndSeparator( "" ) );
-    assertEquals( "", SchedulerFilenameUtils.getNoEndSeparator( "/" ) );
-    assertEquals( "/foo", SchedulerFilenameUtils.getNoEndSeparator( "/foo" ) );
-    assertEquals( "/bar", SchedulerFilenameUtils.getNoEndSeparator( "/bar/" ) );
-    assertEquals( "/a/b/c", SchedulerFilenameUtils.getNoEndSeparator( "/a/b/c/" ) );
-    assertEquals( "/a/b/c/d", SchedulerFilenameUtils.getNoEndSeparator( "/a/b/c/d" ) );
-    assertEquals( "/a/bee/c/duck", SchedulerFilenameUtils.getNoEndSeparator( "/a/bee/c/duck" ) );
+    assertNull( SchedulerFilenameUtils.getNoEndSeparator( (StringBuilder) null ) );
+    assertEquals( "", SchedulerFilenameUtils.getNoEndSeparator( toSb( "" ) ).toString() );
+    assertEquals( "", SchedulerFilenameUtils.getNoEndSeparator( toSb( "/" ) ).toString() );
+    assertEquals( "/foo", SchedulerFilenameUtils.getNoEndSeparator( toSb(  "/foo" ) ).toString() );
+    assertEquals( "/bar", SchedulerFilenameUtils.getNoEndSeparator(  toSb(  "/bar/" ) ).toString() );
+    assertEquals( "/a/b/c", SchedulerFilenameUtils.getNoEndSeparator(  toSb( "/a/b/c/" ) ).toString() );
+    assertEquals( "/a/b/c/d", SchedulerFilenameUtils.getNoEndSeparator( toSb( "/a/b/c/d" ) ).toString() );
+    assertEquals( "/a/bee/c/duck", SchedulerFilenameUtils.getNoEndSeparator( toSb( "/a/bee/c/duck" ) ).toString() );
+  }
+
+  @Test
+  public void testIndexOfLastSeparator() {
+    assertEquals( -1, SchedulerFilenameUtils.indexOfLastSeparator( null ) );
+    assertEquals( -1, SchedulerFilenameUtils.indexOfLastSeparator( toSb( "noseparator.inthispath" ) ) );
+    assertEquals( -1, SchedulerFilenameUtils.indexOfLastSeparator( toSb( "\\windows\\seperator\\not\\supported" ) ) );
+    assertEquals( 4, SchedulerFilenameUtils.indexOfLastSeparator( toSb( "/x/y/z" ) ) );
+    assertEquals( 6, SchedulerFilenameUtils.indexOfLastSeparator( toSb( "/x/y/z/" ) ) );
+    assertEquals( 0, SchedulerFilenameUtils.indexOfLastSeparator( toSb( "/nop" ) ) );
+    assertEquals( 4, SchedulerFilenameUtils.indexOfLastSeparator( toSb( "/pqr/stuv" ) ) );
+    assertEquals( 3, SchedulerFilenameUtils.indexOfLastSeparator( toSb( "a/b/c" ) ) );
+    assertEquals( 5, SchedulerFilenameUtils.indexOfLastSeparator( toSb( "a/b/c/" ) ) );
+    assertEquals( 1, SchedulerFilenameUtils.indexOfLastSeparator( toSb( "d/ef" ) ) );
+    assertEquals( 3, SchedulerFilenameUtils.indexOfLastSeparator( toSb( "ghi/jklm" ) ) );
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  public void testCheckPath_exceptionThrown_windowsSeparator_begginng() {
+    SchedulerFilenameUtils.checkPath( "\\windows\\relativePath\\aFile.txt" );
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  public void testCheckPath_exceptionThrown_windowsSeparator_middle() {
+    SchedulerFilenameUtils.checkPath( "windows\\relativePath\\aFile.txt" );
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  public void testCheckPath_exceptionThrown_windowsSeparator_end() {
+    SchedulerFilenameUtils.checkPath( "relativePath\\" );
+  }
+
+  @Test( expected = IllegalArgumentException.class )
+  public void testCheckPath_exceptionThrown_windowsSeparator_mix() {
+    SchedulerFilenameUtils.checkPath( "windows/relativePath\\aFile.txt" );
+  }
+
+  public StringBuilder toSb( String str ) {
+    return new StringBuilder( str );
   }
 }


### PR DESCRIPTION
… working with filenames and not a complete relative path

- fully implementing concat, future proofing function

**_THIS DOES NOT NEED TO BE COPIED TO OTHER BASELINES SUCH AS 10.1 and 10.1.0.0_** No known bugs/regression.

This is future proofing possible uses of `SchedulerFilenameUtils#concat`. Current implementation works because the `#concat` function is only getting a relative file path for the second argument. Partial implementing due to release priorities.
`SchedulerFilenameUtils.concat( "/home/randomUser/", "simple_report_name8.prpt" )`

This commit enables 
`SchedulerFilenameUtils.concat( "/home/randomUser/", "randomFolderPath/simple_report_name8.prpt" )`

Using previous jira issue for consistency.

All the above statements can be validated by looking at the unit tests.

Previous PR: https://github.com/pentaho/pentaho-scheduler-plugin/pull/101