### PR TITLE
[BACKLOG-40086] Schedule Output Perspective : Allow user to browse Scheduled contents from a VFS location folder

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/genericfile/GetTreeOptions.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/GetTreeOptions.java
@@ -34,6 +34,54 @@ public class GetTreeOptions {
   @Nullable
   private GenericFilePath expandedPath;
 
+  @Nullable
+  private boolean showHiddenFiles;
+
+  /**
+   * Enum to represent the three filters that can be applied to trees.
+   * Technically, in our model, everything in the tree is a file; folders are just files that have children. We will
+   * call these FileObjects.
+   * To a user, a folder is a folder and a file is a file. These filters already exist in our repository
+   * implementation, so I have perpetuated them in the enum values.
+   */
+  public enum TreeFilter {
+    /**
+     * "Folders" make up the branches of the tree, they have children.
+     */
+    FOLDERS,
+    /**
+     * "Files" are the leaves of the trees, they do not have children.
+     */
+    FILES,
+    /**
+     * All FileObjects in the tree, "Folders" and "Files".
+     */
+    ALL;
+
+    /**
+     * Returns true if the file type passes the filter
+     * @param isFolder
+     * @return
+     */
+    public boolean passesFilter( boolean isFolder ) {
+      switch ( this ) {
+        case FOLDERS:
+          return isFolder;
+        case FILES:
+          return !isFolder;
+        case ALL:
+          return true;
+        default:
+          throw new IllegalArgumentException( "This filter type has not been accounted for." );
+      }
+    }
+  }
+
+  /**
+   * The filter used to narrow down the tree.
+   */
+  private TreeFilter filter = TreeFilter.ALL;
+
   /**
    * Gets the base path of the subtree to retrieve.
    * <p>
@@ -148,6 +196,56 @@ public class GetTreeOptions {
     this.expandedPath = expandedPath;
   }
 
+  /**
+   * Gets the tree filter.
+   *
+   * @return the tree filter.
+   */
+  public TreeFilter getFilter() {
+    return filter;
+  }
+
+  /**
+   * Sets the tree filter.
+   * If a null value is passed, "ALL" filter will be used.
+   *
+   * @param filter
+   */
+  public void setFilter( TreeFilter filter ) {
+    this.filter = ( filter == null ) ? TreeFilter.ALL : filter;
+  }
+
+  /**
+   * Sets the tree filter via parsing string value.
+   *
+   * @param treeFilterString
+   */
+  public void setFilter( String treeFilterString ) throws IllegalArgumentException {
+    if ( treeFilterString == null ) {
+      setFilter( TreeFilter.ALL );
+    } else {
+      setFilter( TreeFilter.valueOf( treeFilterString ) );
+    }
+  }
+
+  /**
+   * Gets the show hidden files value.
+   *
+   * @return the show hidden files value.
+   */
+  public boolean getShowHiddenFiles() {
+    return showHiddenFiles;
+  }
+
+  /**
+   * Sets the show hidden files value.
+   *
+   * @param showHiddenFiles
+   */
+  public void setShowHiddenFiles( boolean showHiddenFiles ) {
+    this.showHiddenFiles = showHiddenFiles;
+  }
+
   @Override
   public boolean equals( Object other ) {
     if ( this == other ) {
@@ -161,11 +259,12 @@ public class GetTreeOptions {
     GetTreeOptions that = (GetTreeOptions) other;
     return Objects.equals( basePath, that.basePath )
       && Objects.equals( maxDepth, that.maxDepth )
-      && Objects.equals( expandedPath, that.expandedPath );
+      && Objects.equals( expandedPath, that.expandedPath )
+      && Objects.equals( filter, that.filter );
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash( basePath, maxDepth, expandedPath );
+    return Objects.hash( basePath, maxDepth, expandedPath, filter );
   }
 }

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
@@ -61,38 +61,38 @@ public interface IGenericFileProvider<T extends IGenericFile> {
   String getType();
 
   /**
-   * Gets a tree of folders.
+   * Gets a tree of files.
    * <p>
-   * The results of this method are cached. To ensure fresh results, the {@link #clearFolderCache()} should be called
+   * The results of this method are cached. To ensure fresh results, the {@link #clearTreeCache()} should be called
    * beforehand.
    *
    * @param options The operation options. These control, for example, whether to return the full tree,
-   *                a subtree of a given base path, as well as the depth of the returned folder tree,
+   *                a subtree of a given base path, as well as the depth of the returned file tree,
    *                amongst other options.
    *                <p>
    *                When the {@link GetTreeOptions#getBasePath() base path option} is {@code null},
    *                then the returned tree should be rooted at the provider's root path. Otherwise, the base path must
    *                be owned by this provider, or an exception is thrown.
    *
-   * @return The folder tree.
+   * @return The file tree.
    * @throws AccessControlException   If the user of the current session does not have permission to browse the
-   *                                  specified folders.
+   *                                  specified files.
    * @throws NotFoundException        If the specified {@link GetTreeOptions#getBasePath() base path option} is not
    *                                  {@code null} and is not owned by this provider.
    * @throws OperationFailedException If the operation fails for any other (checked) reason.
    */
   @NonNull
-  IGenericFileTree getFolderTree( @NonNull GetTreeOptions options )
+  IGenericFileTree getTree( @NonNull GetTreeOptions options )
     throws OperationFailedException;
 
   /**
-   * Clears the cache of folder trees, for the current user session.
+   * Clears the cache of trees, for the current user session.
    *
    * @throws OperationFailedException If the operation fails for some (checked) reason.
-   * @see #getFolderTree(GetTreeOptions)
+   * @see #getTree(GetTreeOptions)
    * @see #createFolder(GenericFilePath)
    */
-  void clearFolderCache() throws OperationFailedException;
+  void clearTreeCache() throws OperationFailedException;
 
 
   /**
@@ -119,7 +119,7 @@ public interface IGenericFileProvider<T extends IGenericFile> {
    * @throws AccessControlException   If the user of the current session does not have permission to create the folder.
    * @throws InvalidPathException If the folder's path is not valid.
    * @throws OperationFailedException If the operation fails for any other (checked) reason.
-   * @see #clearFolderCache()
+   * @see #clearTreeCache()
    */
   boolean createFolder( @NonNull GenericFilePath path ) throws OperationFailedException;
 

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java
@@ -33,22 +33,22 @@ import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
  */
 public interface IGenericFileService {
   /**
-   * Clears the cache of folder trees, for all generic file providers, for the current user session.
+   * Clears the cache of file trees, for all generic file providers, for the current user session.
    *
    * @throws OperationFailedException If the operation fails for some (checked) reason.
-   * @see #getFolderTree(GetTreeOptions)
+   * @see #getTree(GetTreeOptions)
    * @see #createFolder(GenericFilePath)
    */
-  void clearFolderCache() throws OperationFailedException;
+  void clearTreeCache() throws OperationFailedException;
 
   /**
-   * Gets a tree of folders.
+   * Gets a tree of files.
    * <p>
-   * The results of this method are cached. To ensure fresh results, the {@link #clearFolderCache()} should be called
+   * The results of this method are cached. To ensure fresh results, the {@link #clearTreeCache()} should be called
    * beforehand.
    *
    * @param options The operation options. These control, for example, whether to return the full tree,
-   *                a subtree of a given base path, as well as the depth of the returned folder tree,
+   *                a subtree of a given base path, as well as the depth of the returned file tree,
    *                amongst other options.
    *                <p>
    *                When the {@link GetTreeOptions#getBasePath() base path option} is {@code null},
@@ -56,13 +56,13 @@ public interface IGenericFileService {
    *                provider, or at the abstract, top-most root whose children are the providers' root paths, if there
    *                are multiple providers.
    *                Otherwise, the returned tree is rooted at the specified base path.
-   * @return The folder tree.
+   * @return The file tree.
    * @throws AccessControlException   If the user of the current session does not have permission to browse the
-   *                                  specified folders.
+   *                                  specified files.
    * @throws OperationFailedException If the operation fails for any other (checked) reason.
    */
   @NonNull
-  IGenericFileTree getFolderTree( @NonNull GetTreeOptions options ) throws OperationFailedException;
+  IGenericFileTree getTree( @NonNull GetTreeOptions options ) throws OperationFailedException;
 
   /**
    * Checks whether a generic file exists, given its path.
@@ -107,7 +107,7 @@ public interface IGenericFileService {
    * @throws AccessControlException   If the user of the current session does not have permission to create the folder.
    * @throws InvalidPathException     If the folder's path is not valid.
    * @throws OperationFailedException If the operation fails for any other (checked) reason.
-   * @see #clearFolderCache()
+   * @see #clearTreeCache()
    */
   boolean createFolder( @NonNull GenericFilePath path ) throws OperationFailedException;
 
@@ -128,7 +128,7 @@ public interface IGenericFileService {
    * @throws AccessControlException   If the user of the current session does not have permission to create the folder.
    * @throws InvalidPathException     If the folder's path is not valid.
    * @throws OperationFailedException If the operation fails for any other (checked) reason.
-   * @see #clearFolderCache()
+   * @see #clearTreeCache()
    */
   default boolean createFolder( @Nullable String path ) throws OperationFailedException {
     return createFolder( GenericFilePath.parseRequired( path ) );

--- a/api/src/test/java/org/pentaho/platform/api/genericfile/IGenericFileServiceTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/genericfile/IGenericFileServiceTest.java
@@ -41,12 +41,12 @@ class IGenericFileServiceTest {
 
   static class GenericFileServiceForTesting implements IGenericFileService {
     @Override
-    public void clearFolderCache() {
+    public void clearTreeCache() {
     }
 
     @NonNull
     @Override
-    public IGenericFileTree getFolderTree( @NonNull GetTreeOptions options ) {
+    public IGenericFileTree getTree( @NonNull GetTreeOptions options ) {
       throw new UnsupportedOperationException();
     }
 

--- a/core/src/main/java/org/pentaho/platform/genericfile/BaseGenericFileProvider.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/BaseGenericFileProvider.java
@@ -48,7 +48,7 @@ public abstract class BaseGenericFileProvider<T extends IGenericFile> implements
 
     boolean folderCreated = createFolderCore( path );
     if ( folderCreated ) {
-      clearFolderCache();
+      clearTreeCache();
     }
 
     return folderCreated;
@@ -58,14 +58,14 @@ public abstract class BaseGenericFileProvider<T extends IGenericFile> implements
 
   @Override
   @NonNull
-  public IGenericFileTree getFolderTree( @NonNull GetTreeOptions options ) throws OperationFailedException {
+  public IGenericFileTree getTree( @NonNull GetTreeOptions options ) throws OperationFailedException {
 
     Objects.requireNonNull( options );
 
     // (Sonar) Cannot use computeIfAbsent because a checked exception needs to be thrown from the mapping function.
     BaseGenericFileTree tree = cachedTrees.get( options );
     if ( tree == null ) {
-      tree = getFolderTreeCore( options );
+      tree = getFileTreeCore( options );
 
       processExpandedPath( tree, options );
 
@@ -92,7 +92,7 @@ public abstract class BaseGenericFileProvider<T extends IGenericFile> implements
   }
 
   @NonNull
-  protected abstract BaseGenericFileTree getFolderTreeCore( @NonNull GetTreeOptions options )
+  protected abstract BaseGenericFileTree getFileTreeCore( @NonNull GetTreeOptions options )
     throws OperationFailedException;
 
   // region expandPathInTree
@@ -126,7 +126,7 @@ public abstract class BaseGenericFileProvider<T extends IGenericFile> implements
         options.setBasePath( path );
         options.setMaxDepth( 1 );
 
-        BaseGenericFileTree treeWithChildren = (BaseGenericFileTree) getFolderTree( options );
+        BaseGenericFileTree treeWithChildren = (BaseGenericFileTree) getTree( options );
 
         // Steal the children.
         childTrees = treeWithChildren.getChildren();
@@ -156,7 +156,7 @@ public abstract class BaseGenericFileProvider<T extends IGenericFile> implements
   // endregion
 
   @Override
-  public void clearFolderCache() {
+  public void clearTreeCache() {
     cachedTrees.clear();
   }
 }

--- a/core/src/main/java/org/pentaho/platform/genericfile/DefaultGenericFileService.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/DefaultGenericFileService.java
@@ -61,10 +61,10 @@ public class DefaultGenericFileService implements IGenericFileService {
     this.fileProviders = new ArrayList<>( fileProviders );
   }
 
-  public void clearFolderCache() {
+  public void clearTreeCache() {
     for ( IGenericFileProvider<?> fileProvider : fileProviders ) {
       try {
-        fileProvider.clearFolderCache();
+        fileProvider.clearTreeCache();
       } catch ( OperationFailedException e ) {
         // Clear as many as possible. Still, log each failure.
         e.printStackTrace();
@@ -73,12 +73,12 @@ public class DefaultGenericFileService implements IGenericFileService {
   }
 
   @NonNull
-  public IGenericFileTree getFolderTree( @NonNull GetTreeOptions options ) throws OperationFailedException {
+  public IGenericFileTree getTree( @NonNull GetTreeOptions options ) throws OperationFailedException {
 
     Objects.requireNonNull( options );
 
     if ( isSingleProviderMode() ) {
-      return fileProviders.get( 0 ).getFolderTree( options );
+      return fileProviders.get( 0 ).getTree( options );
     }
 
     return options.getBasePath() == null
@@ -100,7 +100,7 @@ public class DefaultGenericFileService implements IGenericFileService {
     OperationFailedException firstProviderException = null;
     for ( IGenericFileProvider<?> fileProvider : fileProviders ) {
       try {
-        rootTree.addChild( fileProvider.getFolderTree( options ) );
+        rootTree.addChild( fileProvider.getTree( options ) );
       } catch ( OperationFailedException e ) {
         if ( firstProviderException == null ) {
           firstProviderException = e;
@@ -137,7 +137,7 @@ public class DefaultGenericFileService implements IGenericFileService {
     // In multi-provider mode, and fetching a subtree based on basePath, the parent path is the parent path of basePath.
     return getOwnerFileProvider( basePath )
       .orElseThrow( () -> new NotFoundException( String.format( "Base path not found '%s'.", basePath ) ) )
-      .getFolderTree( options );
+      .getTree( options );
   }
 
   public boolean doesFileExist( @NonNull GenericFilePath path ) throws OperationFailedException {

--- a/core/src/main/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProvider.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProvider.java
@@ -101,7 +101,7 @@ public class RepositoryFileProvider extends BaseGenericFileProvider<RepositoryFi
   }
 
   @NonNull
-  protected RepositoryFileTree getFolderTreeCore( @NonNull GetTreeOptions options ) throws NotFoundException {
+  protected RepositoryFileTree getFileTreeCore( @NonNull GetTreeOptions options ) throws NotFoundException {
 
     // Get the whole tree under the provider root (VFS connections)?
     GenericFilePath basePath = options.getBasePath();
@@ -114,11 +114,13 @@ public class RepositoryFileProvider extends BaseGenericFileProvider<RepositoryFi
 
     FileService fileService = new FileService();
 
+    String repositoryFilterString = getRepositoryFilter( options.getFilter() );
+
     RepositoryFileTreeDto nativeTree = fileService.doGetTree(
       encodeRepositoryPath( basePath.toString() ),
       options.getMaxDepth(),
-      "*|FOLDERS",
-      true,
+      repositoryFilterString,
+      options.getShowHiddenFiles(),
       false,
       false );
 
@@ -135,6 +137,24 @@ public class RepositoryFileProvider extends BaseGenericFileProvider<RepositoryFi
     repositoryFolder.setCanEdit( false );
 
     return tree;
+  }
+
+  /**
+   * Get the tree filter's corresponding repository filter
+   *
+   * @param treeFilter
+   * @return
+   */
+  protected String getRepositoryFilter( GetTreeOptions.TreeFilter treeFilter ) {
+    switch ( treeFilter ) {
+      case FOLDERS:
+        return "*|FOLDERS";
+      case FILES:
+        return "*|FILES";
+      case ALL:
+      default:
+        return "*";
+    }
   }
 
   @Override

--- a/core/src/test/java/org/pentaho/platform/genericfile/BaseGenericFileProviderTest.java
+++ b/core/src/test/java/org/pentaho/platform/genericfile/BaseGenericFileProviderTest.java
@@ -35,7 +35,7 @@ public class BaseGenericFileProviderTest {
 
     @NonNull
     @Override
-    protected BaseGenericFileTree getFolderTreeCore( @NonNull GetTreeOptions options ) {
+    protected BaseGenericFileTree getFileTreeCore( @NonNull GetTreeOptions options ) {
       throw new UnsupportedOperationException();
     }
 

--- a/core/src/test/java/org/pentaho/platform/genericfile/DefaultGenericFileServiceTest.java
+++ b/core/src/test/java/org/pentaho/platform/genericfile/DefaultGenericFileServiceTest.java
@@ -89,11 +89,11 @@ public class DefaultGenericFileServiceTest {
     public MultipleProviderUseCase() throws OperationFailedException, InvalidGenericFileProviderException {
       provider1Mock = mock( IGenericFileProvider.class );
       tree1Mock = mock( IGenericFileTree.class );
-      doReturn( tree1Mock ).when( provider1Mock ).getFolderTree( any( GetTreeOptions.class ) );
+      doReturn( tree1Mock ).when( provider1Mock ).getTree( any( GetTreeOptions.class ) );
 
       provider2Mock = mock( IGenericFileProvider.class );
       tree2Mock = mock( IGenericFileTree.class );
-      doReturn( tree2Mock ).when( provider2Mock ).getFolderTree( any( GetTreeOptions.class ) );
+      doReturn( tree2Mock ).when( provider2Mock ).getTree( any( GetTreeOptions.class ) );
 
       service = new DefaultGenericFileService( Arrays.asList( provider1Mock, provider2Mock ) );
 
@@ -108,12 +108,12 @@ public class DefaultGenericFileServiceTest {
     IGenericFileProvider<?> providerMock = mock( IGenericFileProvider.class );
 
     IGenericFileTree treeMock = mock( IGenericFileTree.class );
-    when( providerMock.getFolderTree( any( GetTreeOptions.class ) ) ).thenReturn( treeMock );
+    when( providerMock.getTree( any( GetTreeOptions.class ) ) ).thenReturn( treeMock );
 
     DefaultGenericFileService service = new DefaultGenericFileService( Collections.singletonList( providerMock ) );
     GetTreeOptions optionsMock = mock( GetTreeOptions.class );
 
-    IGenericFileTree resultTree = service.getFolderTree( optionsMock );
+    IGenericFileTree resultTree = service.getTree( optionsMock );
 
     assertEquals( treeMock, resultTree );
   }
@@ -124,7 +124,7 @@ public class DefaultGenericFileServiceTest {
 
     MultipleProviderUseCase useCase = new MultipleProviderUseCase();
 
-    IGenericFileTree aggregateTree = useCase.service.getFolderTree( useCase.optionsMock );
+    IGenericFileTree aggregateTree = useCase.service.getTree( useCase.optionsMock );
 
     // ---
 
@@ -151,9 +151,9 @@ public class DefaultGenericFileServiceTest {
 
     doThrow( mock( OperationFailedException.class ) )
       .when( useCase.provider1Mock )
-      .getFolderTree( any( GetTreeOptions.class ) );
+      .getTree( any( GetTreeOptions.class ) );
 
-    IGenericFileTree aggregateTree = useCase.service.getFolderTree( useCase.optionsMock );
+    IGenericFileTree aggregateTree = useCase.service.getTree( useCase.optionsMock );
 
     // ---
 
@@ -170,15 +170,15 @@ public class DefaultGenericFileServiceTest {
     OperationFailedException ex1 = mock( OperationFailedException.class );
     doThrow( ex1 )
       .when( useCase.provider1Mock )
-      .getFolderTree( any( GetTreeOptions.class ) );
+      .getTree( any( GetTreeOptions.class ) );
 
     OperationFailedException ex2 = mock( OperationFailedException.class );
     doThrow( ex2 )
       .when( useCase.provider2Mock )
-      .getFolderTree( any( GetTreeOptions.class ) );
+      .getTree( any( GetTreeOptions.class ) );
 
     try {
-      useCase.service.getFolderTree( useCase.optionsMock );
+      useCase.service.getTree( useCase.optionsMock );
       fail();
     } catch ( OperationFailedException ex ) {
       assertSame( ex1, ex );
@@ -196,7 +196,7 @@ public class DefaultGenericFileServiceTest {
 
     doReturn( mock( GenericFilePath.class ) ).when( useCase.optionsMock ).getBasePath();
 
-    useCase.service.getFolderTree( useCase.optionsMock );
+    useCase.service.getTree( useCase.optionsMock );
   }
 
   @Test
@@ -210,11 +210,11 @@ public class DefaultGenericFileServiceTest {
 
     doReturn( mock( GenericFilePath.class ) ).when( useCase.optionsMock ).getBasePath();
 
-    IGenericFileTree resultTree = useCase.service.getFolderTree( useCase.optionsMock );
+    IGenericFileTree resultTree = useCase.service.getTree( useCase.optionsMock );
 
     assertSame( useCase.tree2Mock, resultTree );
-    verify( useCase.provider2Mock, times( 1 ) ).getFolderTree( useCase.optionsMock );
-    verify( useCase.provider1Mock, never() ).getFolderTree( useCase.optionsMock );
+    verify( useCase.provider2Mock, times( 1 ) ).getTree( useCase.optionsMock );
+    verify( useCase.provider1Mock, never() ).getTree( useCase.optionsMock );
   }
   // endregion
 }

--- a/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPanel.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPanel.java
@@ -430,10 +430,6 @@ public class SchedulesPanel extends SimplePanel {
             return BLANK_VALUE;
           }
 
-          if ( !GenericFileNameUtils.isRepositoryPath( outputPath ) ) {
-            return outputPath;
-          }
-
           outputPath = new SafeHtmlBuilder().appendEscaped( outputPath ).toSafeHtml().asString();
 
           return MessageFormat.format( "<span class='workspace-resource-link' title='{0}'>{0}</span>", outputPath );


### PR DESCRIPTION
Issue: https://hv-eng.atlassian.net/browse/BACKLOG-40086
To be merged with:
- https://github.com/pentaho/pentaho-platform/pull/5562
- https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/191
- https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1028

--
- Add treeFilter TreeOption
- Default treeFilter to ALL if not found
- Throw Exception for invalid treeFilter value
- Enable hyperlinkage for VFS Connection locations to Browse Perspective from Scheduler Perspective
- Where operations that only considered folders will now also consider files, changed methods/variables/endpoints/comments accordingly