### PR TITLE
[BACKLOG-40051] Fixing 10.2 QAT build since changing Boolean to boole…

### DIFF
--- a/core/src/main/java/org/pentaho/platform/web/http/api/resources/services/SchedulerService.java
+++ b/core/src/main/java/org/pentaho/platform/web/http/api/resources/services/SchedulerService.java
@@ -665,7 +665,7 @@ public class SchedulerService implements ISchedulerServicePlugin {
     } );
   }
 
-  protected boolean canAdminister() {
+  protected Boolean canAdminister() {
     return getPolicy().isAllowed( AdministerSecurityAction.NAME );
   }
 


### PR DESCRIPTION
…an caused classes that extends this class and override the 'canAdminister()' method to fail compiling