### PR TITLE
[BACKLOG-40489] Error when accessing browse files with a user with sp…

### DIFF
--- a/core/src/main/java/org/pentaho/platform/web/http/api/resources/GenericFileResource.java
+++ b/core/src/main/java/org/pentaho/platform/web/http/api/resources/GenericFileResource.java
@@ -197,6 +197,8 @@ public class GenericFileResource {
 
   @NonNull
   public String decodePath( @NonNull String path ) {
-    return path.replace( ":", "/" ).replace( "~", ":" );
+    return path.replace( ":", "/" )
+      .replace( "~", ":" )
+      .replace( "\t", "~" );
   }
 }

--- a/core/src/test/java/org/pentaho/platform/web/http/api/resources/GenericFileResourceTest.java
+++ b/core/src/test/java/org/pentaho/platform/web/http/api/resources/GenericFileResourceTest.java
@@ -1,0 +1,48 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2024 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.web.http.api.resources;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.pentaho.platform.genericfile.DefaultGenericFileService;
+
+import static org.mockito.Mockito.mock;
+
+public class GenericFileResourceTest {
+
+  GenericFileResource genericFileResource;
+
+  private static final String ENCODED_SAMPLE_PATH = ":home:Ab`\t!@#$%^&()_+{}<>?'=-yZ~";
+  private static final String EXPECTED_DECODED_SAMPLE_PATH = "/home/Ab`~!@#$%^&()_+{}<>?'=-yZ:";
+
+  @Before
+  public void setUp() throws Exception {
+    genericFileResource = new GenericFileResource( mock( DefaultGenericFileService.class ) );
+  }
+
+  @Test
+  public void testDecodePath() {
+    Assert.assertEquals( "Unexpected path decoding:", EXPECTED_DECODED_SAMPLE_PATH,
+      genericFileResource.decodePath( ENCODED_SAMPLE_PATH ) );
+  }
+}


### PR DESCRIPTION
…ecial characteres (that used to work before)

- Use new Encoder encode function for generic file paths to address handling of "~" in file paths

Related PRs (including this one), to be merged together:
1. https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1762
2. https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1032
3. https://github.com/pentaho/pentaho-scheduler-plugin/pull/164
4. https://github.com/pentaho/pentaho-platform/pull/5583