### PR TITLE
[BACKLOG-40633] Updates for unit tests to run on JDK17. Not upgrading

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,6 +12,10 @@
   <artifactId>pentaho-scheduler-core</artifactId>
   <version>10.2.0.0-SNAPSHOT</version>
 
+  <properties>
+    <maven-surefire-plugin.argLine> --add-opens=java.base/java.lang=ALL-UNNAMED </maven-surefire-plugin.argLine>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.quartz-scheduler</groupId>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -18,6 +18,7 @@
         <gwt.module>org.pentaho.mantle.SchedulingDialogs</gwt.module>
         <gwt.style>OBFUSCATED</gwt.style>
         <gwt.loglevel>ERROR</gwt.loglevel>
+        <maven-surefire-plugin.argLine> --add-opens=java.base/java.lang=ALL-UNNAMED </maven-surefire-plugin.argLine>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
mockito further because the gwtmockito package seems to break with anything later than 4.0.0.  This could be a liability in the future.