### PR TITLE
[BACKLOG-40489] Error when accessing browse files with a user with special characters

### DIFF
--- a/ui/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/OutputLocationUtils.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/OutputLocationUtils.java
@@ -24,6 +24,7 @@ import com.google.gwt.http.client.RequestException;
 import com.google.gwt.http.client.Response;
 import com.google.gwt.user.client.Command;
 import org.pentaho.gwt.widgets.client.genericfile.GenericFileNameUtils;
+import org.pentaho.gwt.widgets.client.utils.NameUtils;
 import org.pentaho.gwt.widgets.client.utils.string.StringUtils;
 import org.pentaho.mantle.client.environment.EnvironmentHelper;
 
@@ -44,7 +45,7 @@ public class OutputLocationUtils {
 
     final String url = EnvironmentHelper.getFullyQualifiedURL()
       + "plugin/scheduler-plugin/api/generic-files/folders/"
-      + GenericFileNameUtils.encodePath( outputLocation );
+      + NameUtils.URLEncode( GenericFileNameUtils.encodePath( outputLocation ) );
 
     RequestBuilder builder = new RequestBuilder( RequestBuilder.HEAD, url );
     // This header is required to force Internet Explorer to not cache values from the GET response.

--- a/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPanel.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPanel.java
@@ -1287,7 +1287,7 @@ public class SchedulesPanel extends SimplePanel {
   private void openOutputLocation( final String outputLocation ) {
     setBrowserPerspective();
     String url = EnvironmentHelper.getFullyQualifiedURL() + "api/mantle/session-variable?key=scheduler_folder&value="
-      + outputLocation;
+      + URL.encodeQueryString( outputLocation );
     RequestBuilder executableTypesRequestBuilder = new CsrfRequestBuilder( RequestBuilder.POST, url );
 
     try {


### PR DESCRIPTION
- URL encode the path passed to /folders endpoint
- URL encode the path passed to the session-variable in the schedules panel

PR Set:
1. https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1034
2. https://github.com/pentaho/pentaho-platform/pull/5593
3. https://github.com/pentaho/pentaho-scheduler-plugin/pull/169