### PR TITLE
[BACKLOG-40475] Browse Perspective: "Open" PVFS file actions

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
@@ -24,6 +24,7 @@ import org.pentaho.platform.api.genericfile.exception.InvalidOperationException;
 import org.pentaho.platform.api.genericfile.exception.NotFoundException;
 import org.pentaho.platform.api.genericfile.exception.OperationFailedException;
 import org.pentaho.platform.api.genericfile.model.IGenericFile;
+import org.pentaho.platform.api.genericfile.model.IGenericFileContentWrapper;
 import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
 
 import java.util.EnumSet;
@@ -149,4 +150,12 @@ public interface IGenericFileProvider<T extends IGenericFile> {
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */
   boolean hasAccess( @NonNull GenericFilePath path, @NonNull EnumSet<GenericFilePermission> permissions );
+
+  /**
+   * Gets a wrapper object containing the target file's content, name, and MIME type.
+   * @param path The string representation of the path of the generic file whose content we wish to access.
+   * @return The generic file's content as an InputStream, wrapped with the associated file name and MIME type.
+   * @throws OperationFailedException If the operation fails for some (checked) reason.
+   */
+  IGenericFileContentWrapper getFileContentWrapper(@NonNull GenericFilePath path ) throws OperationFailedException;
 }

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java
@@ -27,6 +27,7 @@ import org.pentaho.platform.api.genericfile.exception.OperationFailedException;
 import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
 
 import java.util.EnumSet;
+import org.pentaho.platform.api.genericfile.model.IGenericFileContentWrapper;
 
 /**
  * The {@code IGenericFileService} interface contains operations to access and modify generic files.
@@ -167,4 +168,17 @@ public interface IGenericFileService {
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */
   boolean hasAccess( @NonNull GenericFilePath path, @NonNull EnumSet<GenericFilePermission> permissions );
+
+  /**
+   * Gets a wrapper object containing the target file's content, name, and MIME type.
+   * There are various checks on the front end to limit users to only open specific, supported file content MIME types from Browse Perspective.
+   * From an endpoint perspective, the user is free to try to get any file content type (assuming it exists, and they have sufficient access).
+   * For more information on MIME types, @see <a href="https://www.w3.org/wiki/WebIntents/MIME_Types">MIME Types</a>
+   *
+   * @param path The string representation of the path of the generic file whose content we wish to access.
+   * @return The generic file's content as an InputStream, wrapped with the associated file name and MIME type.
+   * @throws AccessControlException If the current user cannot perform this operation.
+   * @throws OperationFailedException If the operation fails for some other (checked) reason.
+   */
+  IGenericFileContentWrapper getFileContentWrapper(@NonNull GenericFilePath path) throws OperationFailedException;
 }

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFileContentWrapper.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFileContentWrapper.java
@@ -1,0 +1,51 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2024 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.api.genericfile.model;
+
+import java.io.InputStream;
+
+
+/**
+ * The {@code IGenericFileContentWrapper} interface contains the necessary information for returning a {@code IGenericFile}'s content.
+ *
+ * It is a Generic implementation of the existing org.pentaho.platform.web.http.api.resources.services.FileService inner-class RepositoryFileToStreamWrapper.
+ */
+public interface IGenericFileContentWrapper {
+
+  /**
+   * Gets the file's content InputStream.
+   */
+  InputStream getInputStream();
+
+  /**
+   * Gets the name of the file associated with the content InputStream.
+   */
+  String getFileName();
+
+  /**
+   * Gets the MIME type of the file's content.
+   *
+   * TODO This value is
+   *
+   * PUC can render
+   */
+  String getMimeType();
+}

--- a/api/src/test/java/org/pentaho/platform/api/genericfile/IGenericFileServiceTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/genericfile/IGenericFileServiceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.pentaho.platform.api.genericfile.exception.InvalidPathException;
 import org.pentaho.platform.api.genericfile.exception.OperationFailedException;
+import org.pentaho.platform.api.genericfile.model.IGenericFileContentWrapper;
 import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
 
 import java.util.EnumSet;
@@ -64,6 +65,10 @@ class IGenericFileServiceTest {
 
     @Override
     public boolean createFolder( @NonNull GenericFilePath path ) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public IGenericFileContentWrapper getFileContentWrapper( @NonNull GenericFilePath path ) {
       throw new UnsupportedOperationException();
     }
   }

--- a/core/src/main/java/org/pentaho/platform/genericfile/BaseGenericFileProvider.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/BaseGenericFileProvider.java
@@ -24,6 +24,7 @@ import org.pentaho.platform.api.genericfile.GetTreeOptions;
 import org.pentaho.platform.api.genericfile.IGenericFileProvider;
 import org.pentaho.platform.api.genericfile.exception.OperationFailedException;
 import org.pentaho.platform.api.genericfile.model.IGenericFile;
+import org.pentaho.platform.api.genericfile.model.IGenericFileContentWrapper;
 import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
 import org.pentaho.platform.genericfile.model.BaseGenericFileTree;
 
@@ -164,4 +165,8 @@ public abstract class BaseGenericFileProvider<T extends IGenericFile> implements
   public void clearTreeCache() {
     cachedTrees.clear();
   }
+
+  @Override
+  public abstract IGenericFileContentWrapper getFileContentWrapper(@NonNull GenericFilePath path )
+    throws OperationFailedException;
 }

--- a/core/src/main/java/org/pentaho/platform/genericfile/DefaultGenericFileService.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/DefaultGenericFileService.java
@@ -31,6 +31,7 @@ import org.pentaho.platform.api.genericfile.exception.InvalidGenericFileProvider
 import org.pentaho.platform.api.genericfile.exception.NotFoundException;
 import org.pentaho.platform.api.genericfile.exception.OperationFailedException;
 import org.pentaho.platform.api.genericfile.model.IGenericFile;
+import org.pentaho.platform.api.genericfile.model.IGenericFileContentWrapper;
 import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
 import org.pentaho.platform.genericfile.model.BaseGenericFile;
 import org.pentaho.platform.genericfile.model.BaseGenericFileTree;
@@ -152,6 +153,11 @@ public class DefaultGenericFileService implements IGenericFileService {
     return getOwnerFileProvider( path )
       .orElseThrow( NotFoundException::new )
       .createFolder( path );
+  }
+
+  @Override public IGenericFileContentWrapper getFileContentWrapper( @NonNull GenericFilePath path )
+    throws OperationFailedException {
+    return getOwnerFileProvider( path ).orElseThrow( NotFoundException::new ).getFileContentWrapper( path );
   }
 
   private Optional<IGenericFileProvider<?>> getOwnerFileProvider( @NonNull GenericFilePath path ) {

--- a/core/src/main/java/org/pentaho/platform/genericfile/model/DefaultGenericFileContentWrapper.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/model/DefaultGenericFileContentWrapper.java
@@ -1,0 +1,50 @@
+/*!
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ *
+ * Copyright (c) 2024 Hitachi Vantara. All rights reserved.
+ *
+ */
+
+package org.pentaho.platform.genericfile.model;
+
+import org.pentaho.platform.api.genericfile.model.IGenericFileContentWrapper;
+
+import java.io.InputStream;
+
+public class DefaultGenericFileContentWrapper implements IGenericFileContentWrapper {
+
+  private final InputStream inputStream;
+  private final String fileName;
+  private final String mimeType;
+
+  public DefaultGenericFileContentWrapper( InputStream inputStream, String fileName, String mimeType ) {
+    this.inputStream = inputStream;
+    this.fileName = fileName;
+    this.mimeType = mimeType;
+  }
+
+  @Override public InputStream getInputStream() {
+    return inputStream;
+  }
+
+  @Override public String getFileName() {
+    return fileName;
+  }
+
+  @Override public String getMimeType() {
+    return mimeType;
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/web/http/api/resources/GenericFileResource.java
+++ b/core/src/main/java/org/pentaho/platform/web/http/api/resources/GenericFileResource.java
@@ -24,13 +24,17 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import org.codehaus.enunciate.jaxrs.ResponseCode;
 import org.codehaus.enunciate.jaxrs.StatusCodes;
+import org.pentaho.platform.api.genericfile.GenericFilePath;
 import org.pentaho.platform.api.genericfile.GetTreeOptions;
 import org.pentaho.platform.api.genericfile.IGenericFileService;
 import org.pentaho.platform.api.genericfile.exception.AccessControlException;
 import org.pentaho.platform.api.genericfile.exception.InvalidOperationException;
 import org.pentaho.platform.api.genericfile.exception.InvalidPathException;
+import org.pentaho.platform.api.genericfile.exception.NotFoundException;
 import org.pentaho.platform.api.genericfile.exception.OperationFailedException;
+import org.pentaho.platform.api.genericfile.model.IGenericFileContentWrapper;
 import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
+import org.pentaho.platform.web.servlet.HttpMimeTypeListener;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -43,7 +47,13 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Objects;
+
+import static org.apache.commons.io.IOUtils.copy;
 
 @Path( "/scheduler-plugin/api/generic-files" )
 public class GenericFileResource {
@@ -196,10 +206,66 @@ public class GenericFileResource {
     }
   }
 
+  @GET
+  @Path( "{path : .+}/content" )
+  @Produces( { MediaType.APPLICATION_JSON } )
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Operation successful" ),
+    @ResponseCode( code = 400, condition = "File path is invalid, or is a folder" ),
+    @ResponseCode( code = 401, condition = "Authentication required" ),
+    @ResponseCode( code = 403, condition = "Access forbidden" ),
+    @ResponseCode( code = 404, condition = "File does not exist or user has no read access to it" ),
+    @ResponseCode( code = 500, condition = "Operation failed" )
+  } )
+  public Response getFileContent( @NonNull @PathParam( "path" ) String filePath ) {
+    try {
+      GenericFilePath genericFilePath = GenericFilePath.parseRequired( decodePath( filePath ) );
+      IGenericFileContentWrapper contentWrapper = genericFileService.getFileContentWrapper( genericFilePath );
+
+      return buildOkResponse( getStreamingOutput( contentWrapper.getInputStream() ), contentWrapper.getFileName(),
+        contentWrapper.getMimeType() );
+
+    } catch ( NotFoundException e ) {
+      throw new WebApplicationException( e, Response.Status.NOT_FOUND );
+    } catch ( InvalidPathException | InvalidOperationException e ) {
+      throw new WebApplicationException( e, Response.Status.BAD_REQUEST );
+    } catch ( AccessControlException e ) {
+      throw new WebApplicationException( e, Response.Status.FORBIDDEN );
+    } catch ( OperationFailedException e ) {
+      throw new WebApplicationException( e, Response.Status.INTERNAL_SERVER_ERROR );
+    }
+  }
+
   @NonNull
   public String decodePath( @NonNull String path ) {
     return path.replace( ":", "/" )
       .replace( "~", ":" )
       .replace( "\t", "~" );
+  }
+
+  protected Response buildOkResponse( StreamingOutput streamingOutput, String fileName, String mimeType ) {
+    Response.ResponseBuilder builder;
+
+    MediaType mediaType;
+    try {
+      mediaType = MediaType.valueOf( mimeType );
+    } catch ( IllegalArgumentException e ) {
+      //Downloadable type
+      mediaType = MediaType.APPLICATION_OCTET_STREAM_TYPE;
+    }
+
+    builder = Response.ok( streamingOutput, mediaType );
+
+    return builder.header( "Content-Disposition", HttpMimeTypeListener.buildContentDispositionValue( fileName, false ) )
+      .build();
+  }
+
+  public StreamingOutput getStreamingOutput( final InputStream is ) {
+    return new StreamingOutput() {
+      @Override
+      public void write( OutputStream output ) throws IOException {
+        copy( is, output );
+      }
+    };
   }
 }

--- a/core/src/test/java/org/pentaho/platform/genericfile/BaseGenericFileProviderTest.java
+++ b/core/src/test/java/org/pentaho/platform/genericfile/BaseGenericFileProviderTest.java
@@ -24,6 +24,7 @@ import org.pentaho.platform.api.genericfile.GenericFilePermission;
 import org.pentaho.platform.api.genericfile.GetTreeOptions;
 import org.pentaho.platform.api.genericfile.exception.OperationFailedException;
 import org.pentaho.platform.api.genericfile.model.IGenericFile;
+import org.pentaho.platform.api.genericfile.model.IGenericFileContentWrapper;
 import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
 import org.pentaho.platform.genericfile.model.BaseGenericFile;
 import org.pentaho.platform.genericfile.model.BaseGenericFileTree;
@@ -60,8 +61,13 @@ public class BaseGenericFileProviderTest {
       throw new UnsupportedOperationException();
     }
 
+
     @Override
     public boolean hasAccess( @NonNull GenericFilePath path, EnumSet<GenericFilePermission> permissions ) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public IGenericFileContentWrapper getFileContentWrapper( @NonNull GenericFilePath path ) {
       throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
PR Set:
1. https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1039
2. https://github.com/pentaho/pentaho-platform/pull/5616
3. https://github.com/pentaho/pentaho-scheduler-plugin/pull/178
4. https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/243

- Introduce new `{path : .+}/content` endpoint to support the opening of PVFS files
- added wrapper class to pass a file's content as InputStream, along with it's name and MIME type, much like FileService.RepositoryFileToStreamWrapper
- heavily borrowed from `FileResource.buildOkResponse( FileService.RepositoryFileToStreamWrapper wrapper )`