### PR TITLE
[BACKLOG-40356] Fixed HTTP status code returned by Generic File  Subtree endpoint for not found/invalid base path

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
@@ -79,7 +79,8 @@ public interface IGenericFileProvider<T extends IGenericFile> {
    *                be owned by this provider, or an exception is thrown.
    *
    * @return The file tree.
-   * @throws NotFoundException If the specified base file does not exist, or the current user is not allowed to read it.
+   * @throws NotFoundException If the specified base file does not exist, is not a folder, or the current user is not
+   *                           allowed to read it.
    * @throws AccessControlException If the current user cannot perform this operation.
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */
@@ -99,11 +100,10 @@ public interface IGenericFileProvider<T extends IGenericFile> {
 
 
   /**
-   * Checks whether a generic file exists and is a folder, given its path.
-   *
+   * Checks whether a generic file exists, is a folder and the current user can read it, given its path.
    *
    * @param path The path of the generic file.
-   * @return {@code true}, if the generic file exists and is a folder; {@code false}, otherwise.
+   * @return {@code true}, if the conditions are met; {@code false}, otherwise.
    * @throws AccessControlException If the current user cannot perform this operation.
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java
@@ -63,7 +63,8 @@ public interface IGenericFileService {
    *                are multiple providers.
    *                Otherwise, the returned tree is rooted at the specified base path.
    * @return The file tree.
-   * @throws NotFoundException If the specified base file does not exist, or the current user is not allowed to read it.
+   * @throws NotFoundException If the specified base file does not exist, is not a folder, or the current user is not
+   *                           allowed to read it.
    * @throws AccessControlException If the current user cannot perform this operation.
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */
@@ -71,10 +72,10 @@ public interface IGenericFileService {
   IGenericFileTree getTree( @NonNull GetTreeOptions options ) throws OperationFailedException;
 
   /**
-   * Checks whether a generic file exists and is a folder, given its path.
+   * Checks whether a generic file exists, is a folder and the current user can read it, given its path.
    *
    * @param path The path of the generic file.
-   * @return {@code true}, if the generic file exists and is a folder; {@code false}, otherwise.
+   * @return {@code true}, if the conditions are met; {@code false}, otherwise.
    * @throws AccessControlException If the current user cannot perform this operation.
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */

--- a/core/src/main/java/org/pentaho/platform/web/http/api/resources/GenericFileResource.java
+++ b/core/src/main/java/org/pentaho/platform/web/http/api/resources/GenericFileResource.java
@@ -72,7 +72,7 @@ public class GenericFileResource {
     @ResponseCode( code = 200, condition = "Operation successful" ),
     @ResponseCode( code = 400, condition = "Filter is invalid" ),
     @ResponseCode( code = 401, condition = "Authentication required" ),
-    @ResponseCode( code = 403, condition = "Access forbidden" ),
+    @ResponseCode( code = 403, condition = "Access forbidden to operation" ),
     @ResponseCode( code = 500, condition = "Operation failed" )
   } )
   public IGenericFileTree getFileTree( @QueryParam( "depth" ) Integer maxDepth,
@@ -97,7 +97,10 @@ public class GenericFileResource {
     @ResponseCode( code = 200, condition = "Operation successful" ),
     @ResponseCode( code = 400, condition = "Base path, expanded path, and/or filter are invalid" ),
     @ResponseCode( code = 401, condition = "Authentication required" ),
-    @ResponseCode( code = 403, condition = "Access forbidden" ),
+    @ResponseCode( code = 403, condition = "Access forbidden to operation" ),
+    @ResponseCode(
+      code = 404,
+      condition = "Base path does not exist, is not a folder or user has no read access to it" ),
     @ResponseCode( code = 500, condition = "Operation failed" )
   } )
   public IGenericFileTree getFileSubtree( @NonNull @PathParam( "path" ) String basePath,
@@ -111,6 +114,8 @@ public class GenericFileResource {
       throw new WebApplicationException( e, Response.Status.FORBIDDEN );
     } catch ( InvalidPathException | IllegalArgumentException e ) {
       throw new WebApplicationException( e, Response.Status.BAD_REQUEST );
+    } catch ( NotFoundException e ) {
+      throw new WebApplicationException( e, Response.Status.NOT_FOUND );
     } catch ( OperationFailedException e ) {
       throw new WebApplicationException( e, Response.Status.INTERNAL_SERVER_ERROR );
     }
@@ -161,8 +166,8 @@ public class GenericFileResource {
     @ResponseCode( code = 204, condition = "Folder exists" ),
     @ResponseCode( code = 400, condition = "Folder path is invalid" ),
     @ResponseCode( code = 401, condition = "Authentication required" ),
-    @ResponseCode( code = 403, condition = "Access forbidden" ),
-    @ResponseCode( code = 404, condition = "Folder does not exist" ),
+    @ResponseCode( code = 403, condition = "Access forbidden to operation" ),
+    @ResponseCode( code = 404, condition = "File does not exist, is not a folder or user has no read access to it" ),
     @ResponseCode( code = 500, condition = "Operation failed" ) } )
   public void doesFolderExist( @NonNull @PathParam( "path" ) String path ) {
     try {


### PR DESCRIPTION
- Took the chance to fix some doclets regarding this condition.

PR set:
- https://github.com/pentaho/pdi-plugins-ee/pull/1160

/cc @pentaho/hoth 