### PR TITLE
[BISERVER-15083] - Indicate Pentaho Server time in PUC Scheduler Screens

### DIFF
--- a/core/src/main/java/org/pentaho/platform/web/http/api/resources/SchedulerResource.java
+++ b/core/src/main/java/org/pentaho/platform/web/http/api/resources/SchedulerResource.java
@@ -55,6 +55,7 @@ import javax.ws.rs.core.Response.Status;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -1586,6 +1587,17 @@ public class SchedulerResource implements ISchedulerResource {
     }
 
     return repositoryFileDtoList;
+  }
+
+  @GET
+  @Path( "/serverTime" )
+  @Produces( TEXT_PLAIN )
+  @StatusCodes( {
+    @ResponseCode( code = 200, condition = "Successfully retrieved server time." ),
+    @ResponseCode( code = 500, condition = "Couldn't get server time." ),
+  } )
+  public String getServerTime() {
+    return "Server time: " + new Date( System.currentTimeMillis() );
   }
 
   protected Response buildOkResponse( Object entity ) {

--- a/ui/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEditor.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEditor.java
@@ -238,12 +238,18 @@ public class ScheduleEditor extends VerticalFlexPanel implements IChangeHandler 
 
     setStylePrimaryName( "scheduleEditor" ); //$NON-NLS-1$
 
+    VerticalFlexPanel comboPanel = new VerticalFlexPanel();
     scheduleCombo = createScheduleCombo();
     Label l = new Label( Messages.getString( "schedule.recurrenceColon" ) );
     l.getElement().setId( RECURRENCE_LABEL );
     l.setStyleName( SCHEDULE_LABEL );
-    add( l );
-    add( scheduleCombo );
+    comboPanel.add( l );
+    comboPanel.add( scheduleCombo );
+    HorizontalFlexPanel rowPanel = new HorizontalFlexPanel();
+    rowPanel.add( comboPanel );
+    rowPanel.setVerticalAlignment( HasVerticalAlignment.ALIGN_BOTTOM );
+    displayServerTime( rowPanel );
+    add( rowPanel );
 
     SimplePanel hspacer = new SimplePanel();
     hspacer.setWidth( "100px" ); //$NON-NLS-1$
@@ -573,6 +579,31 @@ public class ScheduleEditor extends VerticalFlexPanel implements IChangeHandler 
     } catch ( RequestException e ) {
       // TODO Auto-generated catch block
       e.printStackTrace();
+    }
+  }
+
+  private void displayServerTime( Panel parentPanel ) {
+    final String apiEndpoint = ScheduleHelper.getPluginContextURL() + "api/scheduler/serverTime";
+
+    RequestBuilder executableTypesRequestBuilder = new RequestBuilder( RequestBuilder.GET, apiEndpoint );
+    executableTypesRequestBuilder.setHeader( "accept", "text/plain" );
+    final Label serverTimeLabel = new Label();
+    serverTimeLabel.setHorizontalAlignment( HasHorizontalAlignment.ALIGN_RIGHT );
+    parentPanel.add( serverTimeLabel );
+
+    try {
+      executableTypesRequestBuilder.sendRequest( null, new RequestCallback() {
+
+        public void onError( Request request, Throwable exception ) {
+          serverTimeLabel.setText( "Server Time: Could not get server time" );
+        }
+
+        public void onResponseReceived( Request request, Response response ) {
+          serverTimeLabel.setText( response.getText() );
+        }
+      } );
+    } catch ( RequestException e ) {
+      serverTimeLabel.setText( "Server Time: Could not get server time" );
     }
   }
 

--- a/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPanel.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPanel.java
@@ -181,6 +181,7 @@ public class SchedulesPanel extends SimplePanel {
       /* noop */
     }
   };
+  private Label updateableTimeLabel = new Label();
 
   @SuppressWarnings( "unchecked" )
   private Set<JsJob> getSelectedJobs() {
@@ -210,6 +211,7 @@ public class SchedulesPanel extends SimplePanel {
   public SchedulesPanel( final boolean isAdmin, final boolean isScheduler, final boolean canExecuteSchedules ) {
     createUI( isAdmin, isScheduler, canExecuteSchedules );
     refresh();
+    getServerTime();
   }
 
   public void refresh() {
@@ -240,6 +242,29 @@ public class SchedulesPanel extends SimplePanel {
       } );
     } catch ( RequestException e ) {
       errorDialog.center();
+    }
+  }
+
+  public void getServerTime() {
+    final String apiEndpoint = "api/scheduler/serverTime";
+
+    RequestBuilder executableTypesRequestBuilder =
+      createRequestBuilder( RequestBuilder.GET, ScheduleHelper.getPluginContextURL(), apiEndpoint );
+    executableTypesRequestBuilder.setHeader( "accept", "text/plain" );
+
+    try {
+      executableTypesRequestBuilder.sendRequest( null, new RequestCallback() {
+
+        public void onError( Request request, Throwable exception ) {
+          updateableTimeLabel.setText( "Server Time: Could not get server time" );
+        }
+
+        public void onResponseReceived( Request request, Response response ) {
+          updateableTimeLabel.setText( response.getText() );
+        }
+      } );
+    } catch ( RequestException e ) {
+      updateableTimeLabel.setText( "Server Time: Could not get server time" );
     }
   }
 
@@ -985,6 +1010,7 @@ public class SchedulesPanel extends SimplePanel {
     }
 
     bar.add( Toolbar.GLUE );
+    bar.add( updateableTimeLabel );
 
     return bar;
   }

--- a/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPerspectivePanel.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPerspectivePanel.java
@@ -157,6 +157,7 @@ public class SchedulesPerspectivePanel extends SimplePanel {
   public void refresh() {
     schedulesPanel.refresh();
     blockoutPanel.refresh();
+    schedulesPanel.getServerTime();
   }
 
   public interface CellTableResources extends CellTable.Resources {


### PR DESCRIPTION
Created new request and added new UI elements to display the Pentaho Server time in the following PUC Scheduler screens:
 - Manage Schedules
 - Scheduling dialog