### PR TITLE
[BACKLOG-41091] Decode PVFS File Paths: Scheduler Perspective + Browse Perspective missed case

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFileContentWrapper.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFileContentWrapper.java
@@ -42,10 +42,6 @@ public interface IGenericFileContentWrapper {
 
   /**
    * Gets the MIME type of the file's content.
-   *
-   * TODO This value is
-   *
-   * PUC can render
    */
   String getMimeType();
 }

--- a/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPanel.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPanel.java
@@ -58,6 +58,7 @@ import com.google.gwt.view.client.MultiSelectionModel;
 import com.google.gwt.view.client.Range;
 import org.pentaho.gwt.widgets.client.dialogs.IDialogCallback;
 import org.pentaho.gwt.widgets.client.dialogs.MessageDialogBox;
+import org.pentaho.gwt.widgets.client.genericfile.GenericFileNameUtils;
 import org.pentaho.gwt.widgets.client.toolbar.Toolbar;
 import org.pentaho.gwt.widgets.client.toolbar.ToolbarButton;
 import org.pentaho.gwt.widgets.client.utils.NameUtils;
@@ -428,7 +429,11 @@ public class SchedulesPanel extends SimplePanel {
       @Override
       public String getStringValue( JsJob jsJob ) {
         try {
-          String outputPath = jsJob.getOutputPath();
+          /*
+          TODO BACKLOG-41091: Decoding would ideally be coming from the back-end (see also, BACKLOG-41089, BACKLOG-41229)
+           we are effectively decoding the value here only to encode it again a few lines down (preventing double-encoding)
+           */
+          String outputPath = GenericFileNameUtils.urlDecodePvfsFilePath( jsJob.getOutputPath() );
           if ( StringUtils.isEmpty( outputPath ) ) {
             return BLANK_VALUE;
           }


### PR DESCRIPTION
- Remove erroneous comment from previous PR
- decode pvfs file paths for UI/visually while keeping encoded for backend functionality in New Schedule Dialog and in Schedules Perspective

PR Set:
1. https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1777
2. https://github.com/pentaho/pentaho-commons-gwt-modules/pull/1041
3. https://github.com/pentaho/pentaho-platform/pull/5647
4. https://github.com/pentaho/pentaho-scheduler-plugin/pull/183