### PR TITLE
feat: getFile method for generic file service [BACKLOG-42892]

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
@@ -15,8 +15,8 @@ package org.pentaho.platform.api.genericfile;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.pentaho.platform.api.genericfile.exception.AccessControlException;
-import org.pentaho.platform.api.genericfile.exception.InvalidPathException;
 import org.pentaho.platform.api.genericfile.exception.InvalidOperationException;
+import org.pentaho.platform.api.genericfile.exception.InvalidPathException;
 import org.pentaho.platform.api.genericfile.exception.NotFoundException;
 import org.pentaho.platform.api.genericfile.exception.OperationFailedException;
 import org.pentaho.platform.api.genericfile.model.IGenericFile;
@@ -81,8 +81,7 @@ public interface IGenericFileProvider<T extends IGenericFile> {
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */
   @NonNull
-  IGenericFileTree getTree( @NonNull GetTreeOptions options )
-    throws OperationFailedException;
+  IGenericFileTree getTree( @NonNull GetTreeOptions options ) throws OperationFailedException;
 
   /**
    * Clears the cache of trees, for the current user session.
@@ -117,10 +116,11 @@ public interface IGenericFileProvider<T extends IGenericFile> {
    * @return {@code true}, if the folder did not exist and was created; {@code false}, if the folder already existed.
    * @throws AccessControlException    If the current user cannot perform this operation.
    * @throws InvalidPathException      If the folder path is not valid.
-   * @throws InvalidOperationException If the path, or one of its prefixes, does not exist and cannot be created using this service (e.g. connections, buckets);
+   * @throws InvalidOperationException If the path, or one of its prefixes, does not exist and cannot be created using
+   *                                   this service (e.g. connections, buckets);
    *                                   if the path or its longest existing prefix does not reference a folder;
-   *                                   if the path does not exist and the current user is not allowed to create folders on
-   *                                   the folder denoted by its longest existing prefix.
+   *                                   if the path does not exist and the current user is not allowed to create folders
+   *                                   on the folder denoted by its longest existing prefix.
    * @throws OperationFailedException  If the operation fails for some other (checked) reason.
    * @see #clearTreeCache()
    */
@@ -145,13 +145,31 @@ public interface IGenericFileProvider<T extends IGenericFile> {
    * @throws AccessControlException If the current user cannot perform this operation.
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */
-  boolean hasAccess( @NonNull GenericFilePath path, @NonNull EnumSet<GenericFilePermission> permissions );
+  boolean hasAccess( @NonNull GenericFilePath path, @NonNull EnumSet<GenericFilePermission> permissions )
+    throws OperationFailedException;
 
   /**
-   * Gets a wrapper object containing the target file's content, name, and MIME type.
-   * @param path The string representation of the path of the generic file whose content we wish to access.
-   * @return The generic file's content as an InputStream, wrapped with the associated file name and MIME type.
-   * @throws OperationFailedException If the operation fails for some (checked) reason.
+   * Gets the content of a file, given its path.
+   * @param path The path of the file.
+   * @return The file's content wrapper.
+   * @throws NotFoundException        If the specified file does not exist, or the current user is not allowed to read
+   *                                  it.
+   * @throws AccessControlException   If the current user cannot perform this operation.
+   * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */
-  IGenericFileContentWrapper getFileContentWrapper(@NonNull GenericFilePath path ) throws OperationFailedException;
+  @NonNull
+  IGenericFileContentWrapper getFileContentWrapper( @NonNull GenericFilePath path ) throws OperationFailedException;
+
+  /**
+   * Gets a file given its path.
+   *
+   * @param path The path of the file.
+   * @return The file.
+   * @throws NotFoundException        If the specified file does not exist, or the current user is not allowed to
+   *                                  read it.
+   * @throws AccessControlException   If the current user cannot perform this operation.
+   * @throws OperationFailedException If the operation fails for some other (checked) reason.
+   */
+  @NonNull
+  IGenericFile getFile( @NonNull GenericFilePath path ) throws OperationFailedException;
 }

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/exception/NotFoundException.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/exception/NotFoundException.java
@@ -31,4 +31,8 @@ public class NotFoundException extends OperationFailedException {
   public NotFoundException( Throwable cause ) {
     super( cause );
   }
+
+  public NotFoundException( String message, Throwable cause ) {
+    super( message, cause );
+  }
 }

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/exception/OperationFailedException.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/exception/OperationFailedException.java
@@ -33,4 +33,8 @@ public class OperationFailedException extends Exception {
   public OperationFailedException( Throwable cause ) {
     super( cause );
   }
+
+  public OperationFailedException( String message, Throwable cause ) {
+    super( message, cause );
+  }
 }

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFileContentWrapper.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFileContentWrapper.java
@@ -10,19 +10,17 @@
  * Change Date: 2029-07-20
  ******************************************************************************/
 
-
 package org.pentaho.platform.api.genericfile.model;
 
 import java.io.InputStream;
 
-
+// NOTE: Designed after the class
+// {@code org.pentaho.platform.web.http.api.resources.services.FileService.RepositoryFileToStreamWrapper}.
 /**
- * The {@code IGenericFileContentWrapper} interface contains the necessary information for returning a {@code IGenericFile}'s content.
- *
- * It is a Generic implementation of the existing org.pentaho.platform.web.http.api.resources.services.FileService inner-class RepositoryFileToStreamWrapper.
+ * The {@code IGenericFileContentWrapper} interface contains the necessary information for returning a
+ * {@code IGenericFile}'s content.
  */
 public interface IGenericFileContentWrapper {
-
   /**
    * Gets the file's content InputStream.
    */
@@ -35,10 +33,8 @@ public interface IGenericFileContentWrapper {
 
   /**
    * Gets the MIME type of the file's content.
-   *
-   * TODO This value is
-   *
-   * PUC can render
+   * <p>
+   * For more information on MIME types, @see <a href="https://www.w3.org/wiki/WebIntents/MIME_Types">MIME Types</a>
    */
   String getMimeType();
 }

--- a/api/src/test/java/org/pentaho/platform/api/genericfile/IGenericFileServiceTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/genericfile/IGenericFileServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.pentaho.platform.api.genericfile.exception.InvalidPathException;
 import org.pentaho.platform.api.genericfile.exception.OperationFailedException;
+import org.pentaho.platform.api.genericfile.model.IGenericFile;
 import org.pentaho.platform.api.genericfile.model.IGenericFileContentWrapper;
 import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
 
@@ -65,6 +66,11 @@ class IGenericFileServiceTest {
     }
 
     @Override public IGenericFileContentWrapper getFileContentWrapper( @NonNull GenericFilePath path ) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IGenericFile getFile( @NonNull GenericFilePath path ) throws OperationFailedException {
       throw new UnsupportedOperationException();
     }
   }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -76,6 +76,12 @@
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>
+      <artifactId>pentaho-platform-repository</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>pentaho</groupId>
       <artifactId>pentaho-versionchecker</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>

--- a/core/src/main/java/org/pentaho/platform/genericfile/BaseGenericFileProvider.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/BaseGenericFileProvider.java
@@ -220,4 +220,8 @@ public abstract class BaseGenericFileProvider<T extends IGenericFile> implements
   @Override
   public abstract IGenericFileContentWrapper getFileContentWrapper( @NonNull GenericFilePath path )
     throws OperationFailedException;
+
+  @Override
+  @NonNull
+  public abstract IGenericFile getFile( @NonNull GenericFilePath path ) throws OperationFailedException;
 }

--- a/core/src/main/java/org/pentaho/platform/genericfile/DefaultGenericFileService.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/DefaultGenericFileService.java
@@ -148,9 +148,18 @@ public class DefaultGenericFileService implements IGenericFileService {
       .createFolder( path );
   }
 
-  @Override public IGenericFileContentWrapper getFileContentWrapper( @NonNull GenericFilePath path )
+  @Override
+  @NonNull
+  public IGenericFileContentWrapper getFileContentWrapper( @NonNull GenericFilePath path )
     throws OperationFailedException {
     return getOwnerFileProvider( path ).orElseThrow( NotFoundException::new ).getFileContentWrapper( path );
+  }
+
+  @Override
+  @NonNull
+  public IGenericFile getFile( @NonNull GenericFilePath path )
+    throws OperationFailedException {
+    return getOwnerFileProvider( path ).orElseThrow( NotFoundException::new ).getFile( path );
   }
 
   private Optional<IGenericFileProvider<?>> getOwnerFileProvider( @NonNull GenericFilePath path ) {
@@ -160,7 +169,8 @@ public class DefaultGenericFileService implements IGenericFileService {
   }
 
   @Override
-  public boolean hasAccess( @NonNull GenericFilePath path, @NonNull EnumSet<GenericFilePermission> permissions ) {
+  public boolean hasAccess( @NonNull GenericFilePath path, @NonNull EnumSet<GenericFilePermission> permissions )
+    throws OperationFailedException {
     Optional<IGenericFileProvider<?>> fileProvider = getOwnerFileProvider( path );
 
     return fileProvider.isPresent() && fileProvider.get().hasAccess( path, permissions );

--- a/core/src/main/java/org/pentaho/platform/genericfile/providers/repository/model/RepositoryFile.java
+++ b/core/src/main/java/org/pentaho/platform/genericfile/providers/repository/model/RepositoryFile.java
@@ -22,7 +22,7 @@ public class RepositoryFile extends RepositoryObject implements IGenericFile {
   private String username;
 
   public RepositoryFile() {
-    // Necessary for JSON marshalling
+    this.setType( TYPE_FILE );
   }
 
   public String getUsername() {

--- a/core/src/test/java/org/pentaho/platform/genericfile/BaseGenericFileProviderTest.java
+++ b/core/src/test/java/org/pentaho/platform/genericfile/BaseGenericFileProviderTest.java
@@ -68,6 +68,11 @@ public class BaseGenericFileProviderTest {
       throw new UnsupportedOperationException();
     }
 
+    @Override
+    public IGenericFile getFile( @NonNull GenericFilePath path ) {
+      throw new UnsupportedOperationException();
+    }
+
     @NonNull
     @Override
     public Class<T> getFileClass() {

--- a/core/src/test/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProviderTest.java
+++ b/core/src/test/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProviderTest.java
@@ -249,7 +249,7 @@ public class RepositoryFileProviderTest {
   @Test( expected = NotFoundException.class )
   public void testGetTreeThrowsNotFoundExceptionIfBasePathNotOwned() throws OperationFailedException {
     RepositoryFileProvider repositoryProvider =
-      new RepositoryFileProvider( mock( IUnifiedRepository.class ), () -> mock( FileService.class ) );
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), mock( FileService.class ) );
 
     GetTreeOptions options = new GetTreeOptions();
     options.setBasePath( "scheme://path" );
@@ -270,7 +270,7 @@ public class RepositoryFileProviderTest {
       .when( fileServiceMock )
       .doGetTree( any(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean() );
 
-    RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, () -> fileServiceMock );
+    RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, fileServiceMock );
 
     GetTreeOptions options = new GetTreeOptions();
     options.setBasePath( ROOT_PATH );
@@ -294,7 +294,7 @@ public class RepositoryFileProviderTest {
       .doGetTree( any(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean() );
 
     RepositoryFileProvider repositoryProvider =
-      new RepositoryFileProvider( mock( IUnifiedRepository.class ), () -> fileServiceMock );
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock );
 
     GetTreeOptions options = new GetTreeOptions();
     options.setBasePath( (GenericFilePath) null );
@@ -319,7 +319,7 @@ public class RepositoryFileProviderTest {
       .doGetTree( any(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean() );
 
     RepositoryFileProvider repositoryProvider =
-      new RepositoryFileProvider( mock( IUnifiedRepository.class ), () -> fileServiceMock );
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock );
 
     GetTreeOptions options = new GetTreeOptions();
     options.setBasePath( ROOT_PATH );
@@ -344,7 +344,7 @@ public class RepositoryFileProviderTest {
       .doGetTree( any(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean() );
 
     RepositoryFileProvider repositoryProvider =
-      new RepositoryFileProvider( mock( IUnifiedRepository.class ), () -> fileServiceMock );
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock );
 
     GetTreeOptions options = new GetTreeOptions();
     options.setBasePath( ROOT_PATH );
@@ -367,7 +367,7 @@ public class RepositoryFileProviderTest {
       .doGetTree( any(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean() );
 
     RepositoryFileProvider repositoryProvider =
-      new RepositoryFileProvider( mock( IUnifiedRepository.class ), () -> fileServiceMock );
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock );
 
     GetTreeOptions options = new GetTreeOptions();
     options.setBasePath( ROOT_PATH );
@@ -397,7 +397,7 @@ public class RepositoryFileProviderTest {
       .doGetTree( any(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean() );
 
     RepositoryFileProvider repositoryProvider =
-      new RepositoryFileProvider( mock( IUnifiedRepository.class ), () -> fileServiceMock );
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock );
 
     GetTreeOptions options = new GetTreeOptions();
     options.setBasePath( ROOT_PATH );
@@ -428,7 +428,7 @@ public class RepositoryFileProviderTest {
       .doGetTree( any(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean() );
 
     RepositoryFileProvider repositoryProvider =
-      new RepositoryFileProvider( mock( IUnifiedRepository.class ), () -> fileServiceMock );
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock );
 
     GetTreeOptions options = new GetTreeOptions();
     options.setBasePath( ROOT_PATH );

--- a/core/src/test/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProviderTest.java
+++ b/core/src/test/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProviderTest.java
@@ -60,8 +60,6 @@ public class RepositoryFileProviderTest {
 
   static final String ALL_FILTER = "*";
 
-  // region getTree
-
   // region Helpers and Sample Structures
 
   /**
@@ -73,7 +71,7 @@ public class RepositoryFileProviderTest {
    * /public/testFile1
    * /public/testFolder2
    */
-  static class NativeRepositoryScenario {
+  static class NativeDtoRepositoryScenario {
     @NonNull
     public final RepositoryFileTreeDto rootTree;
     @NonNull
@@ -91,26 +89,26 @@ public class RepositoryFileProviderTest {
     @NonNull
     public final RepositoryFileDto testFolder2;
 
-    public NativeRepositoryScenario() {
-      rootFolder = createNativeFile( ROOT_PATH, "", true );
-      rootTree = createNativeTree( rootFolder );
+    public NativeDtoRepositoryScenario() {
+      rootFolder = createNativeFileDto( ROOT_PATH, "", true );
+      rootTree = createNativeTreeDto( rootFolder );
 
       // ---
       // /home
-      homeFolder = createNativeFile( "/home", "home", true );
-      homeTree = createNativeTree( homeFolder );
+      homeFolder = createNativeFileDto( "/home", "home", true );
+      homeTree = createNativeTreeDto( homeFolder );
 
       // ---
       // /public
-      publicFolder = createNativeFile( "/public", "public", true );
-      publicTree = createNativeTree( publicFolder );
+      publicFolder = createNativeFileDto( "/public", "public", true );
+      publicTree = createNativeTreeDto( publicFolder );
 
       testFile1 = createSampleTestFile1();
       testFolder2 = createSampleTestFolder2();
 
       publicTree.setChildren( Arrays.asList(
-        createNativeTree( testFile1 ),
-        createNativeTree( testFolder2 )
+        createNativeTreeDto( testFile1 ),
+        createNativeTreeDto( testFolder2 )
       ) );
 
       rootTree.setChildren( Arrays.asList( homeTree, publicTree ) );
@@ -118,7 +116,7 @@ public class RepositoryFileProviderTest {
 
     @NonNull
     private static RepositoryFileDto createSampleTestFile1() {
-      RepositoryFileDto testFile1 = createNativeFile( "/public/testFile1", "testFile1", false );
+      RepositoryFileDto testFile1 = createNativeFileDto( "/public/testFile1", "testFile1", false );
       testFile1.setHidden( true );
 
       String ellapsedMilliseconds = "100";
@@ -133,7 +131,7 @@ public class RepositoryFileProviderTest {
 
     @NonNull
     private static RepositoryFileDto createSampleTestFolder2() {
-      RepositoryFileDto testFolder2 = createNativeFile( "/public/testFolder2", "testFolder2", true );
+      RepositoryFileDto testFolder2 = createNativeFileDto( "/public/testFolder2", "testFolder2", true );
 
       String ellapsedMilliseconds = "200";
       testFolder2.setLastModifiedDate( ellapsedMilliseconds );
@@ -147,14 +145,14 @@ public class RepositoryFileProviderTest {
   }
 
   @NonNull
-  static RepositoryFileTreeDto createNativeTree( @NonNull RepositoryFileDto nativeFile ) {
+  static RepositoryFileTreeDto createNativeTreeDto( @NonNull RepositoryFileDto nativeFile ) {
     RepositoryFileTreeDto nativeTree = new RepositoryFileTreeDto();
     nativeTree.setFile( nativeFile );
     return nativeTree;
   }
 
   @NonNull
-  private static RepositoryFileDto createNativeFile( String path, String name, boolean isFolder ) {
+  private static RepositoryFileDto createNativeFileDto( String path, String name, boolean isFolder ) {
     RepositoryFileDto nativeFile = new RepositoryFileDto();
     nativeFile.setName( name );
     nativeFile.setPath( path );
@@ -166,8 +164,23 @@ public class RepositoryFileProviderTest {
     return nativeFile;
   }
 
+  @NonNull
+  private static org.pentaho.platform.api.repository2.unified.RepositoryFile createNativeFile( String path,
+                                                                                               String name,
+                                                                                               boolean isFolder ) {
+    Date createdDate = new Date( 100 );
+    Date lastModeDate = new Date( 200 );
+    Date lockDate = new Date();
+    return new org.pentaho.platform.api.repository2.unified.RepositoryFile(
+      "12345", name, isFolder, false, false, false, "versionId", path, createdDate,
+      lastModeDate,
+      false, "lockOwner", "lockMessage", lockDate, "en_US", name + " title", name + " description",
+      null, null, 4096, name + "creatorId", null
+    );
+  }
+
   /**
-   * Represents the basic result structure corresponding to the structure of {@link NativeRepositoryScenario}.
+   * Represents the result structure of a root tree operation for {@link NativeDtoRepositoryScenario}.
    */
   static class RepositoryValidatedScenario {
     @NonNull
@@ -190,7 +203,7 @@ public class RepositoryFileProviderTest {
     public RepositoryValidatedScenario( @NonNull IGenericFileTree tree ) {
       assertNotNull( tree );
       rootTree = tree;
-      rootFolder = assertGenericFolder( tree.getFile() );
+      rootFolder = assertRootFolder( tree.getFile() );
 
       assertEquals( ROOT_PATH, rootFolder.getPath() );
 
@@ -206,15 +219,14 @@ public class RepositoryFileProviderTest {
       homeFolder = assertGenericFolder( homeTree.getFile() );
       assertEquals( "/home", homeFolder.getPath() );
       assertEquals( "home", homeFolder.getName() );
+      assertEquals( ROOT_PATH, homeFolder.getParentPath() );
 
       // ---
       // /public
 
       assertNotNull( rootChildren.get( 1 ) );
       publicTree = rootChildren.get( 1 );
-      publicFolder = assertGenericFolder( publicTree.getFile() );
-      assertEquals( "/public", publicFolder.getPath() );
-      assertEquals( "public", publicFolder.getName() );
+      publicFolder = assertPublicTree( publicTree );
 
       List<IGenericFileTree> publicChildren = publicTree.getChildren();
       assertNotNull( publicChildren );
@@ -237,6 +249,17 @@ public class RepositoryFileProviderTest {
     return new RepositoryValidatedScenario( tree );
   }
 
+  private static @NonNull IGenericFolder assertPublicTree( IGenericFileTree publicTree ) {
+    IGenericFolder publicFolder = assertGenericFolder( publicTree.getFile() );
+
+    assertEquals( "/public", publicFolder.getPath() );
+    assertEquals( "public", publicFolder.getName() );
+    assertEquals( ROOT_PATH, publicFolder.getParentPath() );
+    assertRegularCapabilities( publicFolder );
+
+    return publicFolder;
+  }
+
   @NonNull
   static IGenericFolder assertGenericFolder( IGenericFile file ) {
     assertNotNull( file );
@@ -244,8 +267,33 @@ public class RepositoryFileProviderTest {
     assertTrue( file instanceof IGenericFolder );
     return (IGenericFolder) file;
   }
+
+  @NonNull
+  static IGenericFolder assertRootFolder( IGenericFile file ) {
+    IGenericFolder folder = assertGenericFolder( file );
+
+    assertEquals( ROOT_PATH, file.getPath() );
+    assertNull( file.getParentPath() );
+    assertEquals( Messages.getString( "GenericFileRepository.REPOSITORY_FOLDER_DISPLAY" ), file.getName() );
+
+    assertFalse( folder.isCanDelete() );
+    assertFalse( folder.isCanEdit() );
+    assertFalse( folder.isCanAddChildren() );
+    return folder;
+  }
+
+  @NonNull
+  static void assertRegularCapabilities( IGenericFile file ) {
+    assertTrue( file.isCanDelete() );
+    assertTrue( file.isCanEdit() );
+    if ( file.isFolder() ) {
+      IGenericFolder folder = (IGenericFolder) file;
+      assertTrue( folder.isCanAddChildren() );
+    }
+  }
   // endregion
 
+  // region getTree
   @Test( expected = NotFoundException.class )
   public void testGetTreeThrowsNotFoundExceptionIfBasePathNotOwned() throws OperationFailedException {
     RepositoryFileProvider repositoryProvider =
@@ -261,7 +309,7 @@ public class RepositoryFileProviderTest {
   @Test
   public void testGetTreeDelegatesToFileServiceDoGetTree() throws OperationFailedException {
 
-    NativeRepositoryScenario scenario = new NativeRepositoryScenario();
+    NativeDtoRepositoryScenario scenario = new NativeDtoRepositoryScenario();
 
     IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
 
@@ -286,7 +334,7 @@ public class RepositoryFileProviderTest {
 
   @Test
   public void testGetTreeDefaultsBasePathToRepositoryRoot() throws OperationFailedException {
-    NativeRepositoryScenario scenario = new NativeRepositoryScenario();
+    NativeDtoRepositoryScenario scenario = new NativeDtoRepositoryScenario();
 
     FileService fileServiceMock = mock( FileService.class );
     doReturn( scenario.rootTree )
@@ -308,7 +356,7 @@ public class RepositoryFileProviderTest {
 
   @Test
   public void testGetTreeRespectsNullChildrenList() throws OperationFailedException {
-    NativeRepositoryScenario scenario = new NativeRepositoryScenario();
+    NativeDtoRepositoryScenario scenario = new NativeDtoRepositoryScenario();
 
     // Check initial structure has null children list for /home.
     assertNull( scenario.homeTree.getChildren() );
@@ -333,7 +381,7 @@ public class RepositoryFileProviderTest {
 
   @Test
   public void testGetTreeRespectsEmptyChildrenList() throws OperationFailedException {
-    NativeRepositoryScenario scenario = new NativeRepositoryScenario();
+    NativeDtoRepositoryScenario scenario = new NativeDtoRepositoryScenario();
 
     // Set empty list to children of /home.
     scenario.homeTree.setChildren( Collections.emptyList() );
@@ -358,38 +406,8 @@ public class RepositoryFileProviderTest {
   }
 
   @Test
-  public void testGetTreeRootFolderHasExpectedProperties() throws OperationFailedException {
-    NativeRepositoryScenario scenario = new NativeRepositoryScenario();
-
-    FileService fileServiceMock = mock( FileService.class );
-    doReturn( scenario.rootTree )
-      .when( fileServiceMock )
-      .doGetTree( any(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean() );
-
-    RepositoryFileProvider repositoryProvider =
-      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock );
-
-    GetTreeOptions options = new GetTreeOptions();
-    options.setBasePath( ROOT_PATH );
-    options.setMaxDepth( 1 );
-
-    IGenericFileTree tree = repositoryProvider.getTree( options );
-    assertNotNull( tree );
-
-    IGenericFolder rootFolder = assertGenericFolder( tree.getFile() );
-
-    assertEquals( ROOT_PATH, rootFolder.getPath() );
-    assertNull( rootFolder.getParentPath() );
-    assertEquals( Messages.getString( "GenericFileRepository.REPOSITORY_FOLDER_DISPLAY" ), rootFolder.getName() );
-    assertFalse( rootFolder.isCanDelete() );
-    assertFalse( rootFolder.isCanEdit() );
-    assertTrue( rootFolder.isFolder() );
-    assertFalse( rootFolder.isCanAddChildren() );
-  }
-
-  @Test
   public void testGetTreeTestFile1HasExpectedProperties() throws OperationFailedException {
-    NativeRepositoryScenario scenario = new NativeRepositoryScenario();
+    NativeDtoRepositoryScenario scenario = new NativeDtoRepositoryScenario();
 
     FileService fileServiceMock = mock( FileService.class );
     doReturn( scenario.rootTree )
@@ -420,7 +438,7 @@ public class RepositoryFileProviderTest {
 
   @Test
   public void testGetTreeTestFolder2HasExpectedProperties() throws OperationFailedException {
-    NativeRepositoryScenario scenario = new NativeRepositoryScenario();
+    NativeDtoRepositoryScenario scenario = new NativeDtoRepositoryScenario();
 
     FileService fileServiceMock = mock( FileService.class );
     doReturn( scenario.rootTree )
@@ -447,6 +465,96 @@ public class RepositoryFileProviderTest {
     assertEquals( "Test Folder 2 description", testFolder2.getDescription() );
     assertFalse( testFolder2.isHidden() );
     assertEquals( new Date( 200 ), testFolder2.getModifiedDate() );
+  }
+
+  @Test
+  public void testGetSubTreeRootNodeHasExpectedProperties() throws OperationFailedException {
+
+    NativeDtoRepositoryScenario scenario = new NativeDtoRepositoryScenario();
+
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+
+    FileService fileServiceMock = mock( FileService.class );
+    doReturn( scenario.publicTree )
+      .when( fileServiceMock )
+      .doGetTree( any(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean() );
+
+    RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, fileServiceMock );
+
+    GetTreeOptions options = new GetTreeOptions();
+    options.setBasePath( scenario.publicFolder.getPath() );
+    options.setMaxDepth( 1 );
+
+    IGenericFileTree tree = repositoryProvider.getTree( options );
+
+    assertPublicTree( tree );
+  }
+  // endregion
+
+  // region getFile
+  @Test( expected = NotFoundException.class )
+  public void testGetFileThrowsNotFoundExceptionIfPathNotOwned() throws OperationFailedException {
+    RepositoryFileProvider repositoryProvider =
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), mock( FileService.class ) );
+
+    repositoryProvider.getFile( GenericFilePath.parse( "scheme://path" ) );
+  }
+
+  @Test( expected = NotFoundException.class )
+  public void testGetFileThrowsNotFoundExceptionIfPathNotFound() throws OperationFailedException {
+
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    doReturn( null )
+      .when( repositoryMock )
+      .getFile( "/path" );
+
+    RepositoryFileProvider repositoryProvider =
+      new RepositoryFileProvider( repositoryMock, mock( FileService.class ) );
+
+    repositoryProvider.getFile( GenericFilePath.parse( "/path" ) );
+  }
+
+  @Test
+  public void testGetFileRootHasExpectedProperties() throws OperationFailedException {
+
+    org.pentaho.platform.api.repository2.unified.RepositoryFile nativeFile = createNativeFile( ROOT_PATH, "", true );
+
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    doReturn( nativeFile )
+      .when( repositoryMock )
+      .getFile( ROOT_PATH );
+
+    RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, mock( FileService.class ) );
+
+    IGenericFile file = repositoryProvider.getFile( GenericFilePath.parse( ROOT_PATH ) );
+
+    assertRootFolder( file );
+  }
+
+  @Test
+  public void testGetFileRegularHasExpectedProperties() throws OperationFailedException {
+
+    org.pentaho.platform.api.repository2.unified.RepositoryFile nativeFile =
+      createNativeFile( "/public/testFile1", "testFile1", false );
+
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    doReturn( nativeFile )
+      .when( repositoryMock )
+      .getFile( nativeFile.getPath() );
+
+    RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, mock( FileService.class ) );
+
+    IGenericFile file = repositoryProvider.getFile( GenericFilePath.parse( nativeFile.getPath() ) );
+
+    assertEquals( "/public/testFile1", file.getPath() );
+    assertEquals( "/public", file.getParentPath() );
+    assertEquals( "testFile1", file.getName() );
+    assertEquals( "testFile1 title", file.getTitle() );
+    assertEquals( "testFile1 description", file.getDescription() );
+
+    assertEquals( new Date( 200 ), file.getModifiedDate() );
+
+    assertRegularCapabilities( file );
   }
   // endregion
 }


### PR DESCRIPTION
- added corresponding endpoint `GET /plugin/scheduler-plugin/api/generic-files/{id}`
- added missing `getFileContentWrapper` overload for a string path
- fixed documentation of `getFileContentWrapper`
- fixed `getFileContentWrapper` not throwing `NotFoundException`
- fixed repository provider returning wrong name and capabilities for subtree root folders on `getTree` (would return those of the repository root)
- fixed repository files proper having a null type property
- changed to using repository web service's own `DateAdapter` class instead of duplicating code to convert dates back to `Date`

Issue: https://hv-eng.atlassian.net/browse/BACKLOG-42892

@pentaho/millenniumfalcon, please review.

To be merged with:
- https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/289