### PR TITLE
[CLEANUP] adding vesion to org.osgi:osgi.core test

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -98,6 +98,7 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.core</artifactId>
+      <version>${osgi.core.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
was getting a build issue in my IDE due to 

```
    <dependency>
      <groupId>org.osgi</groupId>
      <artifactId>osgi.core</artifactId>
      <scope>test</scope>
    </dependency>
```

not having a version for the test dependency. 

this version comes from https://github.com/pentaho/maven-parent-poms/blob/56f12d84d2fe4e2831171d44e150488fdfa5a2b1/pom.xml#L77C6-L77C23