### PR TITLE
fix: StringIndexOutOfBoundsException displaying schedules with many variables on them

### DIFF
--- a/ui/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/NewScheduleDialog.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/NewScheduleDialog.java
@@ -93,7 +93,7 @@ public class NewScheduleDialog extends PromptDialogBox {
       false, true );
 
     this.jsJob = jsJob;
-    this.filePath = jsJob.getFullResourceName();
+    this.filePath = jsJob.getInputFilePath();
     this.callback = callback;
     this.isEmailConfValid = isEmailConfValid;
 

--- a/ui/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleRecurrenceDialog.java
@@ -115,7 +115,7 @@ public class ScheduleRecurrenceDialog extends AbstractWizardDialog {
       overwrite = !Boolean.parseBoolean( autoCreateUniqueFilename );
     }
 
-    constructDialog( jsJob.getFullResourceName(), jsJob.getOutputPath(), jsJob.getJobName(), dateFormat, overwrite, hasParams,
+    constructDialog( jsJob.getInputFilePath(), jsJob.getOutputPath(), jsJob.getJobName(), dateFormat, overwrite, hasParams,
       isEmailConfValid, jsJob );
 
     setResponsive( true );

--- a/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPanel.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulesPanel.java
@@ -241,7 +241,7 @@ public class SchedulesPanel extends SimplePanel {
   }
 
   private void filterAndShowData() {
-    filters.add( job -> !job.getFullResourceName().equals( "GeneratedContentCleaner" ) );
+    filters.add( job -> !job.getInputFilePath().equals( "GeneratedContentCleaner" ) );
 
     ArrayList<JsJob> filteredList = new ArrayList<>();
 
@@ -411,7 +411,7 @@ public class SchedulesPanel extends SimplePanel {
     HtmlColumn<JsJob> resourceColumn = new HtmlColumn<JsJob>() {
       @Override
       public String getStringValue( JsJob job ) {
-        String fullName = job.getFullResourceName();
+        String fullName = job.getInputFilePath();
         if ( null == fullName || fullName.isEmpty() ) {
           return "";
         }
@@ -1057,7 +1057,7 @@ public class SchedulesPanel extends SimplePanel {
     final Map<String, List<JsJob>> candidateJobs = new HashMap<>( jobs.size() );
 
     for ( JsJob job : jobs ) {
-      List<JsJob> jobList = candidateJobs.computeIfAbsent( job.getFullResourceName(), k -> new ArrayList<>() );
+      List<JsJob> jobList = candidateJobs.computeIfAbsent( job.getInputFilePath(), k -> new ArrayList<>() );
       jobList.add( job );
     }
 
@@ -1370,7 +1370,7 @@ public class SchedulesPanel extends SimplePanel {
   }
 
   private void canAccessJobRequest( final JsJob job, RequestCallback callback ) {
-    final String jobId = pathToId( job.getFullResourceName() );
+    final String jobId = pathToId( job.getInputFilePath() );
 
     final String apiEndpoint =
       "api/repo/files/" + jobId + "/canAccess?cb=" + System.currentTimeMillis() + "&permissions=" + READ_PERMISSION;
@@ -1391,7 +1391,7 @@ public class SchedulesPanel extends SimplePanel {
     int idx = 0;
 
     for ( JsJob job : jobs ) {
-      jobNameList.set( idx++, new JSONString( job.getFullResourceName() ) );
+      jobNameList.set( idx++, new JSONString( job.getInputFilePath() ) );
     }
 
     final JSONObject payload = new JSONObject();

--- a/ui/src/main/java/org/pentaho/mantle/client/workspace/dialogs/ExecuteAvailable.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/workspace/dialogs/ExecuteAvailable.java
@@ -62,7 +62,7 @@ public class ExecuteAvailable extends PromptDialogBox {
 
     String noPermissionsValue = this.noPermissionJobs
       .stream()
-      .map( JsJob::getFullResourceName )
+      .map( JsJob::getInputFilePath )
       .collect( Collectors.joining( "\n" ) );
     content.add( new TextCopyToClipboard( noPermissionsValue ) );
 

--- a/ui/src/main/java/org/pentaho/mantle/client/workspace/dialogs/PermissionDenied.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/workspace/dialogs/PermissionDenied.java
@@ -58,7 +58,7 @@ public class PermissionDenied extends PromptDialogBox {
 
     String noPermissionsValue = this.noPermissionJobs
       .stream()
-      .map( JsJob::getFullResourceName )
+      .map( JsJob::getInputFilePath )
       .collect( Collectors.joining( "\n" ) );
     content.add( new TextCopyToClipboard( noPermissionsValue ) );
 

--- a/ui/src/test/java/org/pentaho/mantle/client/workspace/JsJobTest.java
+++ b/ui/src/test/java/org/pentaho/mantle/client/workspace/JsJobTest.java
@@ -37,34 +37,48 @@ public class JsJobTest {
   }
 
   @Test
-  public void getFullResourceName_nullParam() {
+  public void getInputFilePath_nullParam() {
 
-    doCallRealMethod().when( jsJob ).getFullResourceName();
+    doCallRealMethod().when( jsJob ).getInputFilePath();
 
     // test JobParamValue = null
     when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) ).thenReturn( null );
-    String resourceName = jsJob.getFullResourceName();
+    String resourceName = jsJob.getInputFilePath();
 
     verify( jsJob, times( 1 ) ).getJobName();
     assertNull( resourceName );
   }
 
   @Test
-  public void getFullResourceName_validParam() {
+  public void getInputFilePath_validParam_camelCase() {
 
-    doCallRealMethod().when( jsJob ).getFullResourceName();
+    doCallRealMethod().when( jsJob ).getInputFilePath();
 
     // test JobParamValue = some_valid_value
     when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
-      .thenReturn( ":inputFile = /some_valid_value:outputFile = /another_valid_value" );
-    String resourceName = jsJob.getFullResourceName();
+      .thenReturn( "input file = /some_valid_value:outputFile = /another_valid_value" );
+    String resourceName = jsJob.getInputFilePath();
     
+    assertEquals( "/some_valid_value", resourceName );
+  }
+
+  @Test
+  public void getInputFilePath_validParam_spaceCase() {
+
+    doCallRealMethod().when( jsJob ).getInputFilePath();
+
+    // test JobParamValue = some_valid_value
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
+     .thenReturn( "input file = /some_valid_value:output file=/another_valid_value" );
+    String resourceName = jsJob.getInputFilePath();
+
     assertEquals( "/some_valid_value", resourceName );
   }
 
   @Test
   public void getScheduledExtn_basicPaths() {
     doCallRealMethod().when( jsJob ).getScheduledExtn();
+    doCallRealMethod().when( jsJob ).getInputFilePath();
 
     // Test jobs scheduled from PUC
     when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider-InputFile" ) )
@@ -107,6 +121,7 @@ public class JsJobTest {
   @Test
   public void getScheduledExtn_unusualPaths() {
     doCallRealMethod().when( jsJob ).getScheduledExtn();
+    doCallRealMethod().when( jsJob ).getInputFilePath();
 
     // Test jobs scheduled from PUC
     when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider-InputFile" ) )
@@ -181,6 +196,11 @@ public class JsJobTest {
 
     when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
       .thenReturn( "input file = /home/admin/with.dot:colon=equals/myJob.kjb:outputFile = /home/admin/myJob.*" );
+    assertEquals( "/home/admin", jsJob.getOutputPath() );
+
+    // ":output file=" format
+    when( jsJob.getJobParamValue( "ActionAdapterQuartzJob-StreamProvider" ) )
+     .thenReturn( "input file = /home/admin/myTransformation.ktr:output file=/home/admin/myTransformation.*" );
     assertEquals( "/home/admin", jsJob.getOutputPath() );
   }
 }


### PR DESCRIPTION
This allows the UI to parse the "ActionAdapterQuartzJob-StreamProvider" parameter with either supported format for retrocompatibility:
- "input file = /some_valid_value:**outputFile =** /another_valid_value"
- "input file = /some_valid_value:**output file=**/another_valid_value"

@pentaho/tatooine_dev please review