### PR TITLE
feat: added IGenericFileService getRootTrees method [BACKLOG-42892]

### DIFF
--- a/generic-file-system/api/src/main/java/org/pentaho/platform/api/genericfile/GetTreeOptions.java
+++ b/generic-file-system/api/src/main/java/org/pentaho/platform/api/genericfile/GetTreeOptions.java
@@ -12,6 +12,7 @@
 
 package org.pentaho.platform.api.genericfile;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import org.pentaho.platform.api.genericfile.exception.InvalidPathException;
 
@@ -30,7 +31,12 @@ public class GetTreeOptions {
   @Nullable
   private GenericFilePath expandedPath;
 
-  private boolean showHiddenFiles;
+  @Nullable
+  private Integer expandedMaxDepth;
+
+  private boolean includeHidden;
+
+  private boolean bypassCache;
 
   /**
    * Enum to represent the three filters that can be applied to trees.
@@ -75,7 +81,27 @@ public class GetTreeOptions {
   /**
    * The filter used to narrow down the tree.
    */
+  @NonNull
   private TreeFilter filter = TreeFilter.ALL;
+
+  public GetTreeOptions() {
+  }
+
+  /**
+   * Copy constructor.
+   * @param other The options instance from which to initialize this instance.
+   */
+  public GetTreeOptions( @NonNull GetTreeOptions other ) {
+    Objects.requireNonNull( other );
+
+    this.basePath = other.basePath;
+    this.maxDepth = other.maxDepth;
+    this.expandedPath = other.expandedPath;
+    this.expandedMaxDepth = other.expandedMaxDepth;
+    this.includeHidden = other.includeHidden;
+    this.bypassCache = other.bypassCache;
+    this.filter = other.filter;
+  }
 
   /**
    * Gets the base path of the subtree to retrieve.
@@ -129,18 +155,51 @@ public class GetTreeOptions {
   /**
    * Sets the maximum depth of the subtree to retrieve.
    * <p>
+   * This option may also affect the depth below a specified expanded path, {@link #setExpandedPath(String)}.
+   * <p>
    * When set to {@code null}, there is no limit to the depth of the subtree to retrieve.
    * <p>
-   * Setting to a number less than one results in setting to a {@code null} value.
+   * Setting to a number less than zero results in setting to a {@code null} value.
    * <p>
-   * When {@link #getBasePath() base path} is specified, a depth of {@code 1} corresponds to its children.
-   * When base path is not specified, a depth of {@code 1} corresponds to the children of the root folder of each
-   * generic file provider.
+   * The exact semantics of this parameter depends on the operation being called. For more information, please see the
+   * documentation for {@link IGenericFileService#getTree(GetTreeOptions)} and
+   * {@link IGenericFileService#getRootTrees(GetTreeOptions)}.
    *
    * @param maxDepth The maximum depth.
+   * @see #setExpandedPath(String)
+   * @see #setExpandedMaxDepth(Integer)
    */
   public void setMaxDepth( @Nullable Integer maxDepth ) {
-    this.maxDepth = maxDepth != null && maxDepth >= 1 ? maxDepth : null;
+    this.maxDepth = maxDepth != null && maxDepth >= 0 ? maxDepth : null;
+  }
+
+  /**
+   * Gets the maximum depth of the subtree rooted at the expanded path.
+   *
+   * @return The maximum depth of the expanded path.
+   */
+  @Nullable
+  public Integer getExpandedMaxDepth() {
+    return expandedMaxDepth;
+  }
+
+  /**
+   * Sets the maximum depth of the subtree rooted at the expanded path.
+   * <p>
+   * This property is ignored if either the {@link #getExpandedPath() expanded path} or the
+   * {@link #getMaxDepth() maximum depth} options are {@code null}.
+   * <p>
+   * Setting to a number less than zero results in setting to a {@code null} value.
+   * <p>
+   * The <b>effective expanded path's maximum depth</b> is the value of this property, when specified, or the value of
+   * {@link #getMaxDepth()}, otherwise.
+   *
+   * @param expandedMaxDepth The maximum expanded path depth.
+   * @see #setExpandedPath(String)
+   * @see #setMaxDepth(Integer)
+   */
+  public void setExpandedMaxDepth( @Nullable Integer expandedMaxDepth ) {
+    this.expandedMaxDepth = expandedMaxDepth != null && expandedMaxDepth >= 0 ? expandedMaxDepth : null;
   }
 
   /**
@@ -184,6 +243,9 @@ public class GetTreeOptions {
    * {@link #getMaxDepth() maximum depth}.
    * All the ancestors of the expanded path, up to a non-{@code null} {@link #getBasePath() base path}, will be
    * included, along with their direct children.
+   * <p>
+   * Moreover, if the {@link #getExpandedMaxDepth() effective expanded path maximum depth} not {@code null}, the result
+   * will include a subtree of that maximum depth, rooted at the expanded path.
    *
    * @param expandedPath The expanded path.
    */
@@ -196,6 +258,7 @@ public class GetTreeOptions {
    *
    * @return the tree filter.
    */
+  @NonNull
   public TreeFilter getFilter() {
     return filter;
   }
@@ -206,7 +269,7 @@ public class GetTreeOptions {
    *
    * @param filter
    */
-  public void setFilter( TreeFilter filter ) {
+  public void setFilter( @Nullable TreeFilter filter ) {
     this.filter = ( filter == null ) ? TreeFilter.ALL : filter;
   }
 
@@ -224,22 +287,42 @@ public class GetTreeOptions {
   }
 
   /**
-   * Gets the show hidden files value.
+   * Gets a value that indicates whether hidden files are included in the result.
    * <p>
    * Defaults to {@code false}.
-   * @return the show hidden files value.
+   * @return {@code true} to include hidden files; {@code false}, otherwise.
    */
-  public boolean getShowHiddenFiles() {
-    return showHiddenFiles;
+  public boolean isIncludeHidden() {
+    return includeHidden;
   }
 
   /**
    * Sets the show hidden files value.
    *
-   * @param showHiddenFiles
+   * @param includeHidden {@code true} to include hidden files; {@code false}, otherwise.
    */
-  public void setShowHiddenFiles( boolean showHiddenFiles ) {
-    this.showHiddenFiles = showHiddenFiles;
+  public void setIncludeHidden( boolean includeHidden ) {
+    this.includeHidden = includeHidden;
+  }
+
+  /**
+   * Gets a value that indicates if the cache is to be bypassed.
+   *
+   * @return {@code true} to bypass the cache; {@code false}, otherwise.
+   */
+  public boolean isBypassCache() {
+    return bypassCache;
+  }
+
+  /**
+   * Sets a value that indicates if the cache is to be bypassed.
+   * <p>
+   * Defaults to {@code false}.
+   *
+   * @param bypassCache {@code true} to bypass the cache; {@code false}, otherwise.
+   */
+  public void setBypassCache( boolean bypassCache ) {
+    this.bypassCache = bypassCache;
   }
 
   @Override
@@ -256,11 +339,13 @@ public class GetTreeOptions {
     return Objects.equals( basePath, that.basePath )
       && Objects.equals( maxDepth, that.maxDepth )
       && Objects.equals( expandedPath, that.expandedPath )
-      && Objects.equals( filter, that.filter );
+      && Objects.equals( filter, that.filter )
+      && Objects.equals( includeHidden, that.includeHidden )
+      && Objects.equals( bypassCache, that.bypassCache );
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash( basePath, maxDepth, expandedPath, filter );
+    return Objects.hash( basePath, maxDepth, expandedPath, filter, includeHidden, bypassCache );
   }
 }

--- a/generic-file-system/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
+++ b/generic-file-system/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
@@ -24,6 +24,7 @@ import org.pentaho.platform.api.genericfile.model.IGenericFileContentWrapper;
 import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
 
 import java.util.EnumSet;
+import java.util.List;
 
 /**
  * The {@code IGenericFileProvider} interface contains operations to access and modify generic files
@@ -63,36 +64,46 @@ public interface IGenericFileProvider<T extends IGenericFile> {
   /**
    * Gets a tree of files.
    * <p>
-   * The results of this method are cached. To ensure fresh results, the {@link #clearTreeCache()} should be called
+   * The results of this method are cached. To ensure fresh results, set {@link GetTreeOptions#setBypassCache(boolean)}
+   * to {@code true} or call {@link #clearTreeCache()} beforehand.
    * beforehand.
    *
-   * @param options The operation options. These control, for example, whether to return the full tree,
-   *                a subtree of a given base path, as well as the depth of the returned file tree,
-   *                amongst other options.
-   *                <p>
-   *                When the {@link GetTreeOptions#getBasePath() base path option} is {@code null},
-   *                then the returned tree should be rooted at the provider's root path. Otherwise, the base path must
-   *                be owned by this provider, or an exception is thrown.
-   *
+   * @param options The operation options.
    * @return The file tree.
    * @throws NotFoundException If the specified base file does not exist, is not a folder, or the current user is not
    *                           allowed to read it.
    * @throws AccessControlException If the current user cannot perform this operation.
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
+   * @see IGenericFileService#getTree(GetTreeOptions)
    */
   @NonNull
   IGenericFileTree getTree( @NonNull GetTreeOptions options ) throws OperationFailedException;
 
   /**
-   * Clears the cache of trees, for the current user session.
+   * Gets a list of the real root trees that this provider provides to the generic file system.
+   * <p>
+   * The returned root tree folders are considered to have a depth of {@code 0}.
+   * <p>
+   * The results of this method are not cached, and so {@link GetTreeOptions#isBypassCache()} is ignored.
    *
-   * @see #getTree(GetTreeOptions)
-   * @see #createFolder(GenericFilePath)
+   * @param options The operation options.
+   * @return A list of the real root trees provided by this provider.
    * @throws AccessControlException If the current user cannot perform this operation.
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
+   * @see IGenericFileService#getRootTrees(GetTreeOptions)
+   */
+  @NonNull
+  List<IGenericFileTree> getRootTrees( @NonNull GetTreeOptions options ) throws OperationFailedException;
+
+  /**
+   * Clears the cache of trees, for the current user session.
+   *
+   * @throws AccessControlException If the current user cannot perform this operation.
+   * @throws OperationFailedException If the operation fails for some other (checked) reason.
+   * @see #getTree(GetTreeOptions)
+   * @see #createFolder(GenericFilePath)
    */
   void clearTreeCache() throws OperationFailedException;
-
 
   /**
    * Checks whether a generic file exists, is a folder and the current user can read it, given its path.
@@ -139,6 +150,7 @@ public interface IGenericFileProvider<T extends IGenericFile> {
 
   /**
    * Checks whether a generic file exists and the current user has the specified permissions on it.
+   *
    * @param path The string representation of the path of the generic folder to create.
    * @param permissions Set of permissions needed for any operation like READ/WRITE/DELETE
    * @return {@code true}, if the conditions are; {@code false}, otherwise.
@@ -150,6 +162,7 @@ public interface IGenericFileProvider<T extends IGenericFile> {
 
   /**
    * Gets the content of a file, given its path.
+   *
    * @param path The path of the file.
    * @return The file's content wrapper.
    * @throws NotFoundException        If the specified file does not exist, or the current user is not allowed to read

--- a/generic-file-system/api/src/test/java/org/pentaho/platform/api/genericfile/GetTreeOptionsTest.java
+++ b/generic-file-system/api/src/test/java/org/pentaho/platform/api/genericfile/GetTreeOptionsTest.java
@@ -30,6 +30,88 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class GetTreeOptionsTest {
   /**
+   * Tests the {@link GetTreeOptions#GetTreeOptions(GetTreeOptions)} constructor.
+   */
+  @Nested
+  class CopyConstructorTests {
+    @Test
+    void testCopiesAllProperties() throws InvalidPathException {
+      GetTreeOptions options1 = new GetTreeOptions();
+      options1.setBasePath( "/A" );
+      options1.setExpandedPath( "/B" );
+      options1.setMaxDepth( 3 );
+      options1.setExpandedMaxDepth( 5 );
+      options1.setFilter( GetTreeOptions.TreeFilter.FILES );
+      options1.setBypassCache( true );
+      options1.setIncludeHidden( true );
+
+      // ---
+
+      GetTreeOptions options2 = new GetTreeOptions( options1 );
+
+      assertEquals( options1.getBasePath(), options2.getBasePath() );
+      assertEquals( options1.getExpandedPath(), options2.getExpandedPath() );
+      assertEquals( options1.getMaxDepth(), options2.getMaxDepth() );
+      assertEquals( options1.getExpandedMaxDepth(), options2.getExpandedMaxDepth() );
+      assertEquals( options1.getFilter(), options2.getFilter() );
+      assertEquals( options1.isBypassCache(), options2.isBypassCache() );
+      assertEquals( options1.isIncludeHidden(), options2.isIncludeHidden() );
+    }
+
+    @Test
+    void testAcceptsPathSetAsGenericPath() throws InvalidPathException {
+      GetTreeOptions options = new GetTreeOptions();
+      GenericFilePath path = GenericFilePath.parseRequired( "/" );
+
+      options.setBasePath( path );
+
+      assertSame( path, options.getBasePath() );
+    }
+
+    @Test
+    void testAcceptsNullPathAsGenericPath() throws InvalidPathException {
+      GetTreeOptions options = new GetTreeOptions();
+
+      GenericFilePath initialPath = GenericFilePath.parseRequired( "/" );
+      options.setBasePath( initialPath );
+
+      options.setBasePath( (GenericFilePath) null );
+
+      assertNull( options.getBasePath() );
+    }
+
+    @Test
+    void testAcceptsPathSetAsString() throws InvalidPathException {
+      GetTreeOptions options = new GetTreeOptions();
+
+      options.setBasePath( "/" );
+
+      GenericFilePath path = options.getBasePath();
+      assertNotNull( path );
+      assertEquals( "/", path.toString() );
+    }
+
+    @Test
+    void testAcceptsNullPathSetAsString() throws InvalidPathException {
+      GetTreeOptions options = new GetTreeOptions();
+
+      GenericFilePath initialPath = GenericFilePath.parseRequired( "/" );
+      options.setBasePath( initialPath );
+
+      options.setBasePath( (String) null );
+
+      assertNull( options.getBasePath() );
+    }
+
+    @Test
+    void testThrowsInvalidPathExceptionIfInvalidPathSetAsString() {
+      GetTreeOptions options = new GetTreeOptions();
+
+      assertThrows( InvalidPathException.class, () -> options.setBasePath( "foo" ) );
+    }
+  }
+
+  /**
    * Tests the {@link GetTreeOptions#getBasePath()}, {@link GetTreeOptions#setBasePath(String)} and
    * {@link GetTreeOptions#setBasePath(GenericFilePath)} methods.
    */
@@ -171,6 +253,15 @@ class GetTreeOptionsTest {
     }
 
     @Test
+    void testAcceptsBeingSetToZero() {
+      GetTreeOptions options = new GetTreeOptions();
+
+      options.setMaxDepth( 0 );
+
+      assertEquals( 0, options.getMaxDepth() );
+    }
+
+    @Test
     void testAcceptsBeingSetToOne() {
       GetTreeOptions options = new GetTreeOptions();
 
@@ -200,15 +291,6 @@ class GetTreeOptionsTest {
     }
 
     @Test
-    void testNormalizesZeroToNull() {
-      GetTreeOptions options = new GetTreeOptions();
-
-      options.setMaxDepth( 0 );
-
-      assertNull( options.getMaxDepth() );
-    }
-
-    @Test
     void testNormalizesNegativeToNull() {
       GetTreeOptions options = new GetTreeOptions();
 
@@ -218,6 +300,124 @@ class GetTreeOptionsTest {
     }
   }
 
+  /**
+   * Tests the {@link GetTreeOptions#getExpandedMaxDepth()} and {@link GetTreeOptions#setExpandedMaxDepth(Integer)} methods.
+   */
+  @Nested
+  class ExpandedMaxDepthTests {
+    @Test
+    void testDefaultsToNull() {
+      GetTreeOptions options = new GetTreeOptions();
+      assertNull( options.getExpandedMaxDepth() );
+    }
+
+    @Test
+    void testAcceptsBeingSetToZero() {
+      GetTreeOptions options = new GetTreeOptions();
+
+      options.setExpandedMaxDepth( 0 );
+
+      assertEquals( 0, options.getExpandedMaxDepth() );
+    }
+
+    @Test
+    void testAcceptsBeingSetToOne() {
+      GetTreeOptions options = new GetTreeOptions();
+
+      options.setExpandedMaxDepth( 1 );
+
+      assertEquals( 1, options.getExpandedMaxDepth() );
+    }
+
+    @Test
+    void testAcceptsBeingSetToTwo() {
+      GetTreeOptions options = new GetTreeOptions();
+
+      options.setExpandedMaxDepth( 2 );
+
+      assertEquals( 2, options.getExpandedMaxDepth() );
+    }
+
+    @Test
+    void testAcceptsBeingResetToNullInteger() {
+      GetTreeOptions options = new GetTreeOptions();
+
+      options.setExpandedMaxDepth( 1 );
+
+      options.setExpandedMaxDepth( null );
+
+      assertNull( options.getExpandedMaxDepth() );
+    }
+
+    @Test
+    void testNormalizesNegativeToNull() {
+      GetTreeOptions options = new GetTreeOptions();
+
+      options.setExpandedMaxDepth( -1 );
+
+      assertNull( options.getExpandedMaxDepth() );
+    }
+  }
+
+  /**
+   * Tests the {@link GetTreeOptions#isBypassCache()} and {@link GetTreeOptions#setBypassCache(boolean)} methods.
+   */
+  @Nested
+  class BypassCacheTests {
+    @Test
+    void testDefaultsToFalse() {
+      GetTreeOptions options = new GetTreeOptions();
+      assertFalse( options.isBypassCache() );
+    }
+
+    @Test
+    void testAcceptsBeingSetToTrue() {
+      GetTreeOptions options = new GetTreeOptions();
+
+      options.setBypassCache( true );
+
+      assertTrue( options.isBypassCache() );
+    }
+
+    @Test
+    void testAcceptsBeingSetToFalse() {
+      GetTreeOptions options = new GetTreeOptions();
+
+      options.setBypassCache( false );
+
+      assertFalse( options.isBypassCache() );
+    }
+  }
+
+  /**
+   * Tests the {@link GetTreeOptions#isIncludeHidden()} and {@link GetTreeOptions#setIncludeHidden(boolean)} methods.
+   */
+  @Nested
+  class IncludeHiddenTests {
+    @Test
+    void testDefaultsToFalse() {
+      GetTreeOptions options = new GetTreeOptions();
+      assertFalse( options.isIncludeHidden() );
+    }
+
+    @Test
+    void testAcceptsBeingSetToTrue() {
+      GetTreeOptions options = new GetTreeOptions();
+
+      options.setIncludeHidden( true );
+
+      assertTrue( options.isIncludeHidden() );
+    }
+
+    @Test
+    void testAcceptsBeingSetToFalse() {
+      GetTreeOptions options = new GetTreeOptions();
+
+      options.setIncludeHidden( false );
+
+      assertFalse( options.isIncludeHidden() );
+    }
+  }
 
   /**
    * Tests the {@link GetTreeOptions#equals(Object)} and {@link GetTreeOptions#hashCode()} methods.
@@ -253,11 +453,19 @@ class GetTreeOptionsTest {
       options1.setBasePath( "/" );
       options1.setMaxDepth( 1 );
       options1.setExpandedPath( "scheme://my/folder" );
+      options1.setExpandedMaxDepth( 2 );
+      options1.setFilter( GetTreeOptions.TreeFilter.FILES );
+      options1.setIncludeHidden( true );
+      options1.setBypassCache( true );
 
       GetTreeOptions options2 = new GetTreeOptions();
       options2.setBasePath( "/" );
       options2.setMaxDepth( 1 );
       options2.setExpandedPath( "scheme://my/folder" );
+      options2.setExpandedMaxDepth( 2 );
+      options2.setFilter( GetTreeOptions.TreeFilter.FILES );
+      options2.setIncludeHidden( true );
+      options2.setBypassCache( true );
 
       assertTrue( options1.equals( options2 ) );
       assertEquals( options1.hashCode(), options2.hashCode() );

--- a/generic-file-system/api/src/test/java/org/pentaho/platform/api/genericfile/IGenericFileServiceTest.java
+++ b/generic-file-system/api/src/test/java/org/pentaho/platform/api/genericfile/IGenericFileServiceTest.java
@@ -23,6 +23,7 @@ import org.pentaho.platform.api.genericfile.model.IGenericFileContentWrapper;
 import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
 
 import java.util.EnumSet;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -47,6 +48,12 @@ class IGenericFileServiceTest {
     @NonNull
     @Override
     public IGenericFileTree getTree( @NonNull GetTreeOptions options ) {
+      throw new UnsupportedOperationException();
+    }
+
+    @NonNull
+    @Override
+    public List<IGenericFileTree> getRootTrees( @NonNull GetTreeOptions options ) {
       throw new UnsupportedOperationException();
     }
 

--- a/generic-file-system/impl/src/test/java/org/pentaho/platform/genericfile/DefaultGenericFileServiceTest.java
+++ b/generic-file-system/impl/src/test/java/org/pentaho/platform/genericfile/DefaultGenericFileServiceTest.java
@@ -220,6 +220,68 @@ public class DefaultGenericFileServiceTest {
   }
   // endregion
 
+  // region getRootTrees()
+  private static class GetRootTreesMultipleProviderUseCase extends MultipleProviderUseCase {
+    public final IGenericFileTree tree1Mock;
+    public final IGenericFileTree tree2Mock;
+    public final IGenericFileTree tree3Mock;
+    public final IGenericFileTree tree4Mock;
+
+    public final GetTreeOptions optionsMock;
+
+    public GetRootTreesMultipleProviderUseCase() throws OperationFailedException, InvalidGenericFileProviderException {
+      tree1Mock = mock( IGenericFileTree.class );
+      tree2Mock = mock( IGenericFileTree.class );
+      doReturn( List.of( tree1Mock, tree2Mock) ).when( provider1Mock ).getRootTrees( any( GetTreeOptions.class ) );
+
+      tree3Mock = mock( IGenericFileTree.class );
+      tree4Mock = mock( IGenericFileTree.class );
+      doReturn( List.of( tree3Mock, tree4Mock) ).when( provider2Mock ).getRootTrees( any( GetTreeOptions.class ) );
+
+      optionsMock = mock( GetTreeOptions.class );
+    }
+  }
+
+  @Test
+  public void testGetTreeWithMultipleProvidersAggregatesAllProvidersRootTrees()
+    throws InvalidGenericFileProviderException, OperationFailedException {
+
+    GetRootTreesMultipleProviderUseCase useCase = new GetRootTreesMultipleProviderUseCase();
+
+    List<IGenericFileTree> rootTrees = useCase.service.getRootTrees( useCase.optionsMock );
+
+    // ---
+
+    assertNotNull( rootTrees );
+    assertEquals( 4, rootTrees.size() );
+    assertSame( useCase.tree1Mock, rootTrees.get( 0 ) );
+    assertSame( useCase.tree2Mock, rootTrees.get( 1 ) );
+    assertSame( useCase.tree3Mock, rootTrees.get( 2 ) );
+    assertSame( useCase.tree4Mock, rootTrees.get( 3 ) );
+  }
+
+
+  @Test
+  public void testGetTreeWithMultipleProvidersIgnoresFailedProviders()
+    throws InvalidGenericFileProviderException, OperationFailedException {
+
+    GetRootTreesMultipleProviderUseCase useCase = new GetRootTreesMultipleProviderUseCase();
+
+    doThrow( mock( OperationFailedException.class ) )
+      .when( useCase.provider1Mock )
+      .getRootTrees( any( GetTreeOptions.class ) );
+
+    List<IGenericFileTree> rootTrees = useCase.service.getRootTrees( useCase.optionsMock );
+
+    // ---
+
+    assertNotNull( rootTrees );
+    assertEquals( 2, rootTrees.size() );
+    assertSame( useCase.tree3Mock, rootTrees.get( 0 ) );
+    assertSame( useCase.tree4Mock, rootTrees.get( 1 ) );
+  }
+  // endregion
+
   // region getFile
   private static class GetFileMultipleProviderUseCase extends MultipleProviderUseCase {
     public final IGenericFile file1Mock;


### PR DESCRIPTION
- Added support for `GetTreeOptions#getMaxDepth` of 0
- Added support for `GetTreeOptions#getExpandedMaxDepth`, allowing for a separate depth for the main tree and the expanded paths
- Added support for `GetTreeOptions#isBypassCache` for `getTree` operation
- Changed repository root's name to match the path, and title to have the localized text (important for expand path child search).
- Renamed `GetTreeOptions#showHiddenFiles` to `includeHidden`
- Fixed `GetTreeOptions#equals` and `hashCode`, not including `showHiddenFiles`
- Added missing `GetTreeOptions` tests

PR set:
- https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/296

/cc @pentaho/millenniumfalcon