### PR TITLE
fix: Schedule a Report - Execute Now after Report is Run for the first time and in the next minute - Reports are generated twice

### DIFF
--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -310,7 +310,9 @@ public class QuartzScheduler implements IScheduler {
 
         calendarIntervalTrigger.setRepeatInterval( triggerInterval );
         calendarIntervalTrigger.setRepeatIntervalUnit( intervalUnit );
-        calendarIntervalTrigger.setMisfireInstruction( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_FIRE_ONCE_NOW );
+        // Set the misfire instruction to ignore misfires. This is required due to triggerNow() requiring to
+        // update the previous fire time to the current time, which Quartz does not allow.
+        calendarIntervalTrigger.setMisfireInstruction( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_DO_NOTHING );
         if ( null != triggerEndDate ) {
           calendarIntervalTrigger.setEndTime( triggerEndDate );
         }
@@ -559,15 +561,15 @@ public class QuartzScheduler implements IScheduler {
           continue;
         }
 
-        AbstractTrigger<?> abstractTrigger = (AbstractTrigger<?>) trigger;
-        // Update trigger with the execution date
-        // this ensures the Last Run column shows this manual execution
-        abstractTrigger.setPreviousFireTime( new Date() );
-        // Set misfire instruction to "do nothing" to ensure no misfire run is triggered on `rescheduleJob()`call
-        abstractTrigger.setMisfireInstruction( CronTrigger.MISFIRE_INSTRUCTION_DO_NOTHING );
-
-        // Replace the original trigger (this does not cause the job to run due to MISFIRE_INSTRUCTION_DO_NOTHING)
-        scheduler.rescheduleJob( new TriggerKey( jobId, groupName ), trigger );
+        if ( !previousFireTimeInMisfireWindow( trigger ) ) {
+          AbstractTrigger<?> abstractTrigger = (AbstractTrigger<?>) trigger;
+          // Update trigger with the execution date
+          //   this ensures the Last Run column shows this manual execution
+          abstractTrigger.setPreviousFireTime( new Date() );
+          // Reschedule the original trigger to update the previous fire time
+          //   this does not cause the job to run as long as we are not inside the misfire window
+          scheduler.rescheduleJob( trigger.getKey(), trigger );
+        }
 
         // Execute the job
         scheduler.triggerJob( new JobKey( jobId, groupName ) );
@@ -575,6 +577,48 @@ public class QuartzScheduler implements IScheduler {
     } catch ( org.quartz.SchedulerException e ) {
       throw new SchedulerException( Messages.getInstance().getString(
         "QuartzScheduler.ERROR_0007_FAILED_TO_GET_JOB", jobId ), e );
+    }
+  }
+
+  private boolean previousFireTimeInMisfireWindow( Trigger trigger ) throws org.quartz.SchedulerException {
+    Scheduler scheduler = getQuartzScheduler();
+    long misfireThresholdMillis = getMisfireThresholdMillis( scheduler );
+    long currentTime = System.currentTimeMillis();
+    // previous fire time is next fire time minus repeat interval, so that it's not affected by manual triggers
+    // this is only possible for CalendarIntervalTriggers, not CronTriggers
+    long previousFireTime;
+    if ( trigger instanceof CalendarIntervalTrigger ) {
+      previousFireTime = trigger.getNextFireTime().getTime() - getRepeatIntervalMillis( trigger );
+    } else {
+      previousFireTime = trigger.getPreviousFireTime().getTime();
+    }
+    return currentTime - previousFireTime < misfireThresholdMillis;
+  }
+
+  private static long getMisfireThresholdMillis( Scheduler scheduler ) throws org.quartz.SchedulerException {
+    String misfireThreshold = (String) scheduler.getContext().get( "org.quartz.jobStore.misfireThreshold" );
+    return misfireThreshold == null ? 60000 : Long.parseLong( misfireThreshold );
+  }
+
+  private static long getRepeatIntervalMillis( Trigger trigger ) {
+    if ( trigger instanceof CalendarIntervalTrigger ) {
+      CalendarIntervalTrigger calendarIntervalTrigger = (CalendarIntervalTrigger) trigger;
+      DateBuilder.IntervalUnit intervalUnit = calendarIntervalTrigger.getRepeatIntervalUnit();
+      int repeatInterval = calendarIntervalTrigger.getRepeatInterval();
+      switch ( intervalUnit ) {
+        case SECOND:
+          return repeatInterval * 1000L;
+        case MINUTE:
+          return repeatInterval * 60 * 1000L;
+        case HOUR:
+          return repeatInterval * 60 * 60 * 1000L;
+        case DAY:
+          return repeatInterval * 24 * 60 * 60 * 1000L;
+        default:
+          return 0;
+      }
+    } else {
+      return 0;
     }
   }
 


### PR DESCRIPTION
@pentaho/tatooine_dev 