### PR TITLE
[BACKLOG-42985] Fixing a race condition in the UI on initialization.

### DIFF
--- a/ui/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEditor.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/dialogs/scheduling/ScheduleEditor.java
@@ -561,6 +561,9 @@ public class ScheduleEditor extends VerticalFlexPanel implements IChangeHandler 
               break;
             }
           }
+          if ( null != onChangeHandler ) {
+            onChangeHandler.onHandle( ScheduleEditor.this );
+          }
         }
 
         @Override


### PR DESCRIPTION
The check for whether the Next/Finish button could be enabled was happening before the time zone picker list was getting populated. Fix is to directly invoke the change handler callback after the list gets populated to update the button state.