### PR TITLE
fix: consider ComplexJobTrigger in "previousFireTimeInMisfireWindow" validation

### DIFF
--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -587,9 +587,10 @@ public class QuartzScheduler implements IScheduler {
     long currentTime = System.currentTimeMillis();
     long previousFireTime;
 
-    if ( trigger instanceof CalendarIntervalTrigger && trigger.getNextFireTime() != null ) {
+    if ( ( trigger instanceof CalendarIntervalTrigger || trigger instanceof ComplexJobTrigger )
+        && trigger.getNextFireTime() != null ) {
       // previous fire time is next fire time minus repeat interval, so that it's not affected by manual triggers
-      // this is only possible for CalendarIntervalTriggers, not CronTriggers
+      // this is only possible for instances of triggers that have a repeat interval, not CronTriggers for example
       previousFireTime = trigger.getNextFireTime().getTime() - getRepeatIntervalMillis( trigger );
     } else if ( trigger.getPreviousFireTime() != null ) {
       previousFireTime = trigger.getPreviousFireTime().getTime();


### PR DESCRIPTION
This pull request includes a modification to the `QuartzScheduler` class to support a new type of trigger in the `previousFireTimeInMisfireWindow` method. The most important change is the addition of support for `ComplexJobTrigger` alongside `CalendarIntervalTrigger`.

* [`core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java`](diffhunk://#diff-7d3d3f5968dacb9cbb5d54570400cbd4a61cc5fd533d8eb706ec0e35d05c8008L590-R593): Modified the `previousFireTimeInMisfireWindow` method to include `ComplexJobTrigger` in the condition that checks for triggers with a repeat interval.

Addresses BISERVER-15156

@pentaho/tatooine, please review