### PR TITLE
feat: reintroduce last run update on manual trigger

### DIFF
--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
@@ -17,10 +17,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.scheduler2.ComplexJobTrigger;
 import org.pentaho.platform.api.scheduler2.Job;
 import org.pentaho.platform.api.scheduler2.SchedulerException;
 import org.pentaho.platform.api.scheduler2.SimpleJobTrigger;
@@ -28,13 +27,20 @@ import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.quartz.CronExpression;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.CronTrigger;
+import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
+import org.quartz.JobKey;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerFactory;
 import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
+import org.quartz.impl.triggers.CalendarIntervalTriggerImpl;
+import org.quartz.impl.triggers.CronTriggerImpl;
+import org.quartz.spi.MutableTrigger;
 
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -42,7 +48,10 @@ import java.util.HashMap;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -57,36 +66,33 @@ public class QuartzSchedulerTest {
 
 
   @BeforeClass
-  public static void setUp() throws Exception {
-
+  public static void setUp() {
     oldRepo = PentahoSystem.get( IUnifiedRepository.class );
     repo = mock( IUnifiedRepository.class );
-    when( repo.getFile( Mockito.anyString() ) ).then( new Answer<Object>() {
-      @Override public Object answer( InvocationOnMock invocationOnMock ) throws Throwable {
-        final RepositoryFile repositoryFile = mock( RepositoryFile.class );
-        final String param = (String) invocationOnMock.getArguments()[ 0 ];
-        if ( "/home/admin/notexist.ktr".equals( param ) ) {
-          return null;
-        }
-        if ( "/home/admin".equals( param ) ) {
-          when( repositoryFile.isFolder() ).thenReturn( true );
-        }
-        if ( "/home/admin/notallowed.ktr".equals( param ) ) {
-          when( repositoryFile.isFolder() ).thenReturn( false );
-          when( repositoryFile.isSchedulable() ).thenReturn( false );
-        }
-        if ( "/home/admin/allowed.ktr".equals( param ) ) {
-          when( repositoryFile.isFolder() ).thenReturn( false );
-          when( repositoryFile.isSchedulable() ).thenReturn( true );
-        }
-        return repositoryFile;
+    when( repo.getFile( Mockito.anyString() ) ).then( invocationOnMock -> {
+      final RepositoryFile repositoryFile = mock( RepositoryFile.class );
+      final String param = (String) invocationOnMock.getArguments()[0];
+      if ( "/home/admin/notexist.ktr".equals( param ) ) {
+        return null;
       }
+      if ( "/home/admin".equals( param ) ) {
+        when( repositoryFile.isFolder() ).thenReturn( true );
+      }
+      if ( "/home/admin/notallowed.ktr".equals( param ) ) {
+        when( repositoryFile.isFolder() ).thenReturn( false );
+        when( repositoryFile.isSchedulable() ).thenReturn( false );
+      }
+      if ( "/home/admin/allowed.ktr".equals( param ) ) {
+        when( repositoryFile.isFolder() ).thenReturn( false );
+        when( repositoryFile.isSchedulable() ).thenReturn( true );
+      }
+      return repositoryFile;
     } );
     PentahoSystem.registerObject( repo, IUnifiedRepository.class );
   }
 
   @AfterClass
-  public static void tearDown() throws Exception {
+  public static void tearDown() {
     repo = null;
     if ( oldRepo != null ) {
       PentahoSystem.registerObject( oldRepo, IUnifiedRepository.class );
@@ -157,7 +163,7 @@ public class QuartzSchedulerTest {
     Job job = new Job();
     QuartzScheduler quartzScheduler = new QuartzScheduler();
     long nowDate = new Date().getTime();
-    long futureDate = nowDate+1000000000;
+    long futureDate = nowDate + 1000000000;
 
     when( trigger.getNextFireTime() ).thenReturn( new Date( futureDate ) );
     when( trigger.getFireTimeAfter( any() ) ).thenReturn( new Date( nowDate ) );
@@ -174,7 +180,7 @@ public class QuartzSchedulerTest {
     Job job = new Job();
     QuartzScheduler quartzScheduler = new QuartzScheduler();
     long nowDate = new Date().getTime();
-    long pastDate = nowDate-1000000000;
+    long pastDate = nowDate - 1000000000;
 
     when( trigger.getNextFireTime() ).thenReturn( new Date( pastDate ) );
     when( trigger.getFireTimeAfter( any() ) ).thenReturn( new Date( nowDate ) );
@@ -197,7 +203,7 @@ public class QuartzSchedulerTest {
 
     quartzScheduler.setJobNextRun( job, trigger );
 
-    assertEquals( null,  job.getNextRun() );
+    assertNull( job.getNextRun() );
   }
 
   @Test
@@ -205,7 +211,11 @@ public class QuartzSchedulerTest {
     SimpleJobTrigger simpleJobTrigger = new SimpleJobTrigger();
     SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
     Scheduler mockScheduler = mock( Scheduler.class );
+    JobDetail mockJobDetail = mock( JobDetail.class );
+    when( mockJobDetail.getKey() ).thenReturn( new org.quartz.JobKey( "fooJob", "fooGroup" ) );
+    when( mockJobDetail.getJobDataMap() ).thenReturn( new JobDataMap() );
     when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
+    when( mockScheduler.getJobDetail( any() ) ).thenReturn( mockJobDetail );
     Calendar testDates = Calendar.getInstance();
     testDates.set( Calendar.SECOND, 0 );
     testDates.set( Calendar.MILLISECOND, 0 );
@@ -227,7 +237,7 @@ public class QuartzSchedulerTest {
     quartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
     HashMap<String, Object> jobParams = new HashMap<>();
     jobParams.put( RESERVEDMAPKEY_ACTIONUSER, "fooUser" );
-    Job job = quartzScheduler.createJob( "fooJob", jobParams, simpleJobTrigger, null );
+    quartzScheduler.createJob( "fooJob", jobParams, simpleJobTrigger, null );
 
     ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass( Trigger.class );
     verify( mockScheduler ).scheduleJob( any( JobDetail.class ), triggerCaptor.capture() );
@@ -237,10 +247,16 @@ public class QuartzSchedulerTest {
 
   @Test
   public void testTriggerEndTimeWithTimeZone() throws SchedulerException, org.quartz.SchedulerException {
+    // Set the default timezone to UTC, so that the test is not affected by the local timezone
+    TimeZone.setDefault( TimeZone.getTimeZone( "UTC" ) );
     SimpleJobTrigger simpleJobTrigger = new SimpleJobTrigger();
     SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
     Scheduler mockScheduler = mock( Scheduler.class );
+    JobDetail mockJobDetail = mock( JobDetail.class );
+    when( mockJobDetail.getKey() ).thenReturn( new org.quartz.JobKey( "fooJob", "fooGroup" ) );
+    when( mockJobDetail.getJobDataMap() ).thenReturn( new JobDataMap() );
     when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
+    when( mockScheduler.getJobDetail( any() ) ).thenReturn( mockJobDetail );
     Calendar testDates = Calendar.getInstance();
     testDates.set( Calendar.SECOND, 0 );
     testDates.set( Calendar.MILLISECOND, 0 );
@@ -269,8 +285,104 @@ public class QuartzSchedulerTest {
     ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass( Trigger.class );
     verify( mockScheduler ).scheduleJob( any( JobDetail.class ), triggerCaptor.capture() );
 
-    // convert the input time and the trigger time to GMT and verify they are the same
+    // convert the input time and the trigger time to UTC and verify they are the same
     assertEquals( testDates.getTime().getTime() + TimeZone.getDefault().getRawOffset(), triggerCaptor.getValue().getEndTime().getTime() + tz.getRawOffset() );
   }
 
+  @Test
+  public void testGetSingleJobTrigger() throws Exception {
+    // Arrange
+    Scheduler mockScheduler = mock( Scheduler.class );
+    JobKey jobKey = new JobKey( "testJob", "testGroup" );
+
+    Trigger manualTrigger = mock( Trigger.class );
+    when( manualTrigger.getKey() ).thenReturn( new TriggerKey( "MT_manualTrigger" ) );
+
+    Trigger validTrigger = mock( Trigger.class );
+    when( validTrigger.getKey() ).thenReturn( new TriggerKey( "validTrigger" ) );
+
+    when( mockScheduler.getTriggersOfJob( jobKey ) ).thenAnswer(
+      unused -> Arrays.asList( manualTrigger, validTrigger ) );
+
+    SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
+    when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
+
+    QuartzScheduler quartzScheduler = new QuartzScheduler();
+    quartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
+
+    // Act
+    Trigger result = quartzScheduler.getSingleJobTrigger( jobKey );
+
+    // Assert
+    assertEquals( validTrigger, result );
+  }
+
+  @Test
+  public void testSetJobNextRun() {
+    // Arrange
+    QuartzScheduler quartzScheduler = new QuartzScheduler();
+    Job job = new Job();
+    Trigger mockTrigger = mock( Trigger.class );
+
+    Date nextFireTime = new Date( System.currentTimeMillis() + 10000 ); // 10 seconds in the future
+    when( mockTrigger.getNextFireTime() ).thenReturn( nextFireTime );
+
+    // Act
+    quartzScheduler.setJobNextRun( job, mockTrigger );
+
+    // Assert
+    assertEquals( nextFireTime, job.getNextRun() );
+  }
+
+  @Test
+  public void testIsManualTrigger() {
+    // Arrange
+    QuartzScheduler quartzScheduler = new QuartzScheduler();
+    Trigger manualTrigger = mock( Trigger.class );
+    when( manualTrigger.getKey() ).thenReturn( new TriggerKey( "MT_manualTrigger" ) );
+
+    Trigger nonManualTrigger = mock( Trigger.class );
+    when( nonManualTrigger.getKey() ).thenReturn( new TriggerKey( "validTrigger" ) );
+
+    // Act & Assert
+    assertTrue( quartzScheduler.isManualTrigger( manualTrigger ) );
+    assertFalse( quartzScheduler.isManualTrigger( nonManualTrigger ) );
+  }
+
+  @Test
+  public void testCreateQuartzTriggerWithSimpleJobTrigger() throws Exception {
+    // Arrange
+    SimpleJobTrigger simpleTrigger = new SimpleJobTrigger();
+    simpleTrigger.setStartTime( new Date() );
+    simpleTrigger.setRepeatInterval( 1000 );
+    simpleTrigger.setRepeatCount( 5 );
+    simpleTrigger.setUiPassParam( "SECONDS" );
+
+    QuartzJobKey jobKey = new QuartzJobKey( "testJob", "testUser" );
+
+    // Act
+    MutableTrigger quartzTrigger = QuartzScheduler.createQuartzTrigger( simpleTrigger, jobKey );
+
+    // Assert
+    assertNotNull( quartzTrigger );
+    assertTrue( quartzTrigger instanceof CalendarIntervalTriggerImpl );
+    assertEquals( 1000, ( (CalendarIntervalTriggerImpl) quartzTrigger ).getRepeatInterval() );
+  }
+
+  @Test
+  public void testCreateQuartzTriggerWithComplexJobTrigger() throws Exception {
+    // Arrange
+    ComplexJobTrigger complexTrigger = new ComplexJobTrigger();
+    complexTrigger.setCronString( "0 0/5 * * * ?" );
+
+    QuartzJobKey jobKey = new QuartzJobKey( "testJob", "testUser" );
+
+    // Act
+    MutableTrigger quartzTrigger = QuartzScheduler.createQuartzTrigger( complexTrigger, jobKey );
+
+    // Assert
+    assertNotNull( quartzTrigger );
+    assertTrue( quartzTrigger instanceof CronTriggerImpl );
+    assertEquals( "0 0/5 * * * ?", ((CronTriggerImpl) quartzTrigger).getCronExpression() );
+  }
 }

--- a/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulerUiUtil.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulerUiUtil.java
@@ -32,6 +32,7 @@ public class SchedulerUiUtil {
     "ActionAdapterQuartzJob-StreamProvider",
     "ActionAdapterQuartzJob-StreamProvider-InputFile",
     "accepted-page",
+    "appendDateFormat",
     "autoCreateUniqueFilename",
     "autoSubmit",
     "autoSubmitUI",

--- a/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulerUiUtil.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulerUiUtil.java
@@ -44,6 +44,7 @@ public class SchedulerUiUtil {
     "lineage-id",
     "logLevel",
     "maximum-query-limit",
+    "previousTriggerNow",
     "query-limit",
     "query-limit-ui-enabled",
     "renderMode",

--- a/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulerUiUtil.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulerUiUtil.java
@@ -27,11 +27,11 @@ import java.util.Map;
 public class SchedulerUiUtil {
   protected static final List<String> INJECTED_JOB_PARAM_NAMES = Arrays.asList(
     "::session",
-    "accepted-page",
     "ActionAdapterQuartzJob-ActionId",
     "ActionAdapterQuartzJob-ActionUser",
-    "ActionAdapterQuartzJob-StreamProvider-InputFile",
     "ActionAdapterQuartzJob-StreamProvider",
+    "ActionAdapterQuartzJob-StreamProvider-InputFile",
+    "accepted-page",
     "autoCreateUniqueFilename",
     "autoSubmit",
     "autoSubmitUI",
@@ -44,8 +44,8 @@ public class SchedulerUiUtil {
     "lineage-id",
     "logLevel",
     "maximum-query-limit",
-    "query-limit-ui-enabled",
     "query-limit",
+    "query-limit-ui-enabled",
     "renderMode",
     "repositoryName",
     "runSafeMode",


### PR DESCRIPTION
⚠️ **Please do not squash and merge this PR** ⚠️ 

Goal:
--
This pull request reintroduces the functionality to update a job's "last run" column in the Scheduler's UI, when a manual trigger (`triggerNow()`) is invoked. It achieves this by utilizing the `previousTriggerNow` property in the JobDataMap. This feature had been previously removed, in https://github.com/pentaho/pentaho-scheduler-plugin/pull/283, because the previous implementation was causing duplicate executions.

To help in the review, I split the implementation into 3 separate PRs:
- [chore: sonar fixes and increased coverage](https://github.com/pentaho/pentaho-scheduler-plugin/pull/295/commits/9006390b2c85217c61260feee21b79392ef3a749)
- [feat: reintroduce last run update on manual trigger](https://github.com/pentaho/pentaho-scheduler-plugin/pull/295/commits/e9200962e133f2574288419ba62cbb5918b35158) the actual development work of [BISERVER-15161](https://hv-eng.atlassian.net/browse/BISERVER-15161)
- [fix: filter appendDateFormat from parameters view](https://github.com/pentaho/pentaho-scheduler-plugin/pull/295/commits/e2cdeb24cdcf7826cff846ad82971cd3c1a4b44a) addresses [BISERVER-15178](https://hv-eng.atlassian.net/browse/BISERVER-15178);

Implementation details:
--
- When `triggerNow()` is called (**"Execute Now"** in the Scheduler's UI), it's execution time is stored in Quartz's `JobDetail.JobDataMap` with the key `previousTriggerNow`. 
  - ⚠️ Since `JobDetail` is an immutable object, it's required to delete the previous entry and create a new one with the updated field. See `updateJobData()`;
- When a read access is made, `getLastRun()` is used to check when the last run happened. This compares the value stored in `previousTriggerNow` with the value from `Trigger.getPreviousFireTime()` (scheduled run), and return the latest;
- Two new entries have been added to `SchedulerUiUtil.INJECTED_JOB_PARAM_NAMES` as to prevent them from appearing in the UI under the **Parameters & Variables** view:
  - `previousTriggerNow` - that was added in this, as previously mentioned;
  - `appendDateFormat` - that had an open bug to also be removed from the UI: [BISERVER-15178](https://hv-eng.atlassian.net/browse/BISERVER-15178);

Additional Changes:
--
- Tackled several Sonar issues and code duplication present in `QuartzScheduler`;
- Added unit tests for the newly implemented code functionality:
  - `testTriggerNowUpdatesJobData`
  - `testGetLastRun_*` - to 4 different conditions
- Added several other unit tests to add coverage to the code affected by this PR;

[BISERVER-15178]: https://hv-eng.atlassian.net/browse/BISERVER-15178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BISERVER-15161]: https://hv-eng.atlassian.net/browse/BISERVER-15161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

@pentaho/tatooine_dev please review