### PR TITLE
fix: Update Last Run on manual trigger without duplicate executions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ target/
 .idea/
 pentaho.log
 null*db
+.vscode/

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
@@ -405,6 +405,9 @@ public class QuartzSchedulerTest {
     // Mock Scheduler and related objects
     Scheduler mockScheduler = mock( Scheduler.class );
     Trigger mockTrigger = mock( Trigger.class );
+    
+    when( mockTrigger.getTriggerBuilder() ).thenAnswer( unused -> TriggerBuilder.newTrigger() );
+    when( mockTrigger.getNextFireTime() ).thenReturn( new Date());
 
     when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
     when( mockScheduler.getTriggersOfJob( jobKey ) )
@@ -424,8 +427,8 @@ public class QuartzSchedulerTest {
 
     // Assert
     assertNotNull( jobDataMap.get( QuartzScheduler.PREVIOUS_TRIGGER_NOW_KEY ) );
-    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), eq( mockTrigger ) );
     verify( mockScheduler ).deleteJob( jobKey );
+    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), any( Trigger.class ) );
     verify( mockScheduler ).triggerJob( jobKey );
   }
 


### PR DESCRIPTION
Fixes the implementation in https://github.com/pentaho/pentaho-scheduler-plugin/pull/295, as part of **BISERVER-15161**

### Summary
This PR fixes a bug where the "Last Run" column in the schedule report UI was not updated after clicking the "Execute Now" button for a scheduled report. The fix ensures that the last execution time is properly updated while avoiding duplicate executions.

---

### Background
This behavior was initially implemented as part of **BISERVER-15156** to prevent duplicate executions when using "Execute Now" on recurring schedules. However, this temporary solution caused the "Last Run" column to remain outdated.

---

### Fix Details
1. **Thread Safety**:
   - Introduced a `ReentrantReadWriteLock` to ensure safe access to `JobDetail` and related operations.

2. **Last Run Update**:
   - Refactored the `triggerNow` logic to update the last execution time without causing duplicate executions.

3. **UI Parameter Handling**:
   - Ensured that the internal parameter `previousTriggerNow` is not exposed in the UI.

4. **Removed `updateJob`**:
   - The `updateJob` method was removed as it relied on `addJob`, which is incompatible with immutable jobs. This implementation was not being used anywhere in the code and would cause an exception if called.
