### PR TITLE
[BACKLOG-44169]-Blockout Status API response returns boolean value where string is expected

### DIFF
--- a/core/src/main/java/org/pentaho/platform/web/http/api/proxies/BlockStatusProxy.java
+++ b/core/src/main/java/org/pentaho/platform/web/http/api/proxies/BlockStatusProxy.java
@@ -44,7 +44,7 @@ public class BlockStatusProxy {
   }
 
   @JsonProperty( "totallyBlocked" )
-  public String getTotallyBlockedString() {
+  public String totallyBlockedString() {
     return String.valueOf( totallyBlocked );
   }
 
@@ -57,7 +57,7 @@ public class BlockStatusProxy {
   }
 
   @JsonProperty( "partiallyBlocked" )
-  public String getPartiallyBlockedString() {
+  public String partiallyBlockedString() {
     return String.valueOf( partiallyBlocked );
   }
 


### PR DESCRIPTION
[BACKLOG-44169]-Blockout Status API response returns boolean value where string is expected