### PR TITLE
fix[BISERVER-15276]: add default UI_PASS_PARAM to allow the import of some schedules exported in 9.x

### DIFF
--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -337,7 +337,7 @@ public class QuartzScheduler implements IScheduler {
                                              Date triggerEndDate, java.util.Calendar startDateCal, TimeZone tz ) {
     if ( simpleTrigger.getUiPassParam() == null ) {
       simpleTrigger.setUiPassParam( UI_PASS_PARAM_DAILY );
-      logger.debug("UiPassParam is null, defaulting to DAILY");
+      logger.debug( "UiPassParam is null, defaulting to DAILY" );
     }
 
     long interval = simpleTrigger.getRepeatInterval();

--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -337,7 +337,7 @@ public class QuartzScheduler implements IScheduler {
                                              Date triggerEndDate, java.util.Calendar startDateCal, TimeZone tz ) {
     if ( simpleTrigger.getUiPassParam() == null ) {
       simpleTrigger.setUiPassParam( UI_PASS_PARAM_DAILY );
-      logger.debug( "UiPassParam is null, defaulting to DAILY" );
+      logger.debug( "UiPassParam is null, defaulting to " + UI_PASS_PARAM_DAILY );
     }
 
     long interval = simpleTrigger.getRepeatInterval();


### PR DESCRIPTION
Main change:
- When `UI_PASS_PARAM` is missing in `configureSimpleTrigger`, we default it to `DAILY` so that old schedules that are missing this parameter can still be imported;


Other changes:
- Made the `logger` variable static in order to call it from static methods + to align with best practices
- Refactored `calculateTriggerInterval()` to make it more coherent with `determineIntervalUnit()`:
  - Turned it into a switch instead of an else-if;
  - Added an exception for when the `UI_PASS_PARAM` value is missing or invalid, instead of returning `0` and the import failing later with a less comprehensive error message.