### PR TITLE
[BACKLOG-44147]-Schedule Job API fails schema validation due to missing @type and incorrect field types

### DIFF
--- a/core/src/main/java/org/pentaho/platform/api/scheduler2/ComplexJobTrigger.java
+++ b/core/src/main/java/org/pentaho/platform/api/scheduler2/ComplexJobTrigger.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.TreeSet;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -82,12 +83,31 @@ public class ComplexJobTrigger extends JobTrigger implements IComplexJobTrigger 
   private SecondWrapper secondRecurrences = new SecondWrapper();
   private long repeatInterval = 0;
   private String cronDescription;
+  private long repeatCount = 0;
 
   public long getRepeatInterval() {
     return repeatInterval;
   }
   public void setRepeatInterval( long repeatIntervalSeconds ) {
     this.repeatInterval = repeatIntervalSeconds;
+  }
+
+  @JsonProperty( "repeatInterval")
+  public String getRepeatIntervalString() {
+    return String.valueOf( repeatInterval );
+  }
+
+  public long getRepeatCount() {
+    return repeatCount;
+  }
+
+  public void setRepeatCount( long repeatCount ) {
+    this.repeatCount = repeatCount;
+  }
+
+  @JsonProperty( "repeatCount" )
+  public String getRepeatCountString() {
+    return String.valueOf( repeatCount );
   }
 
   /**


### PR DESCRIPTION
[BACKLOG-44147]-Schedule Job API fails schema validation due to missing @type and incorrect field types

[BACKLOG-44147]: https://hv-eng.atlassian.net/browse/BACKLOG-44147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ