### PR TITLE
[BACKLOG-44362] Azure Docker Image - Old oracle jar is causing issues…

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -20,11 +20,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.quartz-scheduler</groupId>
-            <artifactId>quartz-oracle</artifactId>
-            <version>${quartz-oracle.version}</version>
-        </dependency>
-        <dependency>
             <groupId>pentaho</groupId>
             <artifactId>pentaho-scheduler-core</artifactId>
             <version>${pentaho-scheduler-plugin.version}</version>

--- a/assembly/src/assembly/assembly.xml
+++ b/assembly/src/assembly/assembly.xml
@@ -26,7 +26,6 @@
         <include>pentaho:pentaho-generic-file-system-api</include>
         <include>pentaho:pentaho-generic-file-system-impl</include>
         <include>org.quartz-scheduler:quartz</include>
-        <include>org.quartz-schedule:quartz-oracle</include>
       </includes>
       <sources>
         <includeModuleDirectory>false</includeModuleDirectory>

--- a/assembly/src/main/quartz/quartz.properties
+++ b/assembly/src/main/quartz/quartz.properties
@@ -185,7 +185,7 @@ org.quartz.threadPool.threadsInheritContextClassLoaderOfInitializingThread = tru
 #         - MSSQLDelegate (for Microsoft SQL Server drivers)
 #         - PostgreSQLDelegate (for PostgreSQL drivers)
 #         - WebLogicDelegate (for WebLogic drivers)
-#         - oracle.OracleDelegate (for Oracle drivers)
+#         - OracleDelegate (for Oracle drivers)
 #
 #     org.quartz.jobStore.useProperties = USE_PROPERTIES
 #     org.quartz.jobStore.dataSource = DS_NAME

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,11 +19,6 @@
   <dependencies>
     <dependency>
       <groupId>org.quartz-scheduler</groupId>
-      <artifactId>quartz-oracle</artifactId>
-      <version>${quartz-oracle.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.quartz-scheduler</groupId>
       <artifactId>quartz</artifactId>
       <version>${quartz.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
     <mail.version>1.6.1</mail.version>
     <webservices.version>2.3.1</webservices.version>
     <quartz.version>2.3.2</quartz.version>
-    <quartz-oracle.version>2.1.7</quartz-oracle.version>
     <jmock.version>2.5.1</jmock.version>
     <mockito-core.version>4.0.0</mockito-core.version>
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>


### PR DESCRIPTION
… to allow connection to the Oracle databases (jackrabbit, hibernate, quartz, pentaho_dilogs, pentaho_operations_mart) -- quartz-oracle is no longer needed since upgrading quartz to 2.3.2.