### PR TITLE
fix[BISERVER-15276]: change the default UI_PASS_PARAM to SECONDS for correct interpretation of Repeat Intervals coming from 9.x

### DIFF
--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -335,9 +335,11 @@ public class QuartzScheduler implements IScheduler {
 
   private static void configureSimpleTrigger( SimpleJobTrigger simpleTrigger, CalendarIntervalTriggerImpl calendarIntervalTrigger,
                                              Date triggerEndDate, java.util.Calendar startDateCal, TimeZone tz ) {
+    // SECONDS is defined as the default, since in 9.x the RepeatInterval value is expressed in seconds,
+    // So the RepeatInterval for schedules coming from 9.x (not including UiPassParam) should be interpreted in seconds
     if ( simpleTrigger.getUiPassParam() == null ) {
-      simpleTrigger.setUiPassParam( UI_PASS_PARAM_DAILY );
-      logger.debug( "UiPassParam is null, defaulting to " + UI_PASS_PARAM_DAILY );
+      simpleTrigger.setUiPassParam( UI_PASS_PARAM_SECONDS );
+      logger.debug( "UiPassParam is null, defaulting to " + UI_PASS_PARAM_SECONDS );
     }
 
     long interval = simpleTrigger.getRepeatInterval();


### PR DESCRIPTION
`UI_PASS_PARAM` `DAILY` was incorrectly dividing the `REPEAT_INTERVAL` values coming from 9.x, as they are expressed in seconds. For that reason, changed the default `UI_PASS_PARAM` (used when it is missing during import, for example for 9.x-exported schedules) to `SECONDS`.