### PR TITLE
build[PPP-5751]: update GWT dependencies to use org.gwtproject groupId

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -23,7 +23,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-user</artifactId>
             <exclusions>
                 <exclusion>
@@ -33,11 +33,11 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-dev</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-codeserver</artifactId>
             <exclusions>
                 <exclusion>
@@ -115,7 +115,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
-                <version>${gwt.version}</version>
+                <version>${gwt-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
**⚠️ Merge only after https://github.com/pentaho/maven-parent-poms/pull/761 has been merged ⚠️** 

This pull request updates the `ui/pom.xml` to improve compatibility with the latest GWT project structure and plugin management. The most important changes focus on updating dependencies to use the new `org.gwtproject` group and switching to a more specific plugin version property.

Dependency updates:

* Changed the group ID for the `gwt-user`, `gwt-dev`, and `gwt-codeserver` dependencies from `com.google.gwt` to `org.gwtproject` to align with the latest GWT project organization. [[1]](diffhunk://#diff-f2b421f2b1e0145e5e60e2f9e90554e0b1adc639138053a504f8e9da90f448ddL216-R216) [[2]](diffhunk://#diff-f2b421f2b1e0145e5e60e2f9e90554e0b1adc639138053a504f8e9da90f448ddL226-R226) [[3]](diffhunk://#diff-f2b421f2b1e0145e5e60e2f9e90554e0b1adc639138053a504f8e9da90f448ddL240-R240)

Plugin configuration:

* Updated the `gwt-maven-plugin` version reference to use the `${gwt-maven-plugin.version}` property instead of `${gwt.version}`, improving clarity and maintainability of plugin version management.