### PR TITLE
[SP-6885][PPP-5768] Minute recurrences were being added to a list alr…

### DIFF
--- a/core/src/main/java/org/pentaho/platform/web/http/api/resources/SchedulerResourceUtil.java
+++ b/core/src/main/java/org/pentaho/platform/web/http/api/resources/SchedulerResourceUtil.java
@@ -147,7 +147,7 @@ public class SchedulerResourceUtil {
         Calendar calendar = Calendar.getInstance();
         calendar.set( proxyTrigger.getStartYear(), proxyTrigger.getStartMonth(), proxyTrigger.getStartDay(), proxyTrigger.getStartHour(), proxyTrigger.getStartMin(), 0 );
         complexJobTrigger.setHourlyRecurrence( calendar.get( Calendar.HOUR_OF_DAY ) );
-        complexJobTrigger.addMinuteRecurrence( calendar.get( Calendar.MINUTE ) );
+        complexJobTrigger.setMinuteRecurrence( calendar.get( Calendar.MINUTE ) );
       }
 
       complexJobTrigger.setStartHour( proxyTrigger.getStartHour() );

--- a/core/src/test/java/org/pentaho/platform/web/http/api/resources/SchedulerResourceUtilTest.java
+++ b/core/src/test/java/org/pentaho/platform/web/http/api/resources/SchedulerResourceUtilTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.scheduler2.ComplexJobTrigger;
 import org.pentaho.platform.api.scheduler2.CronJobTrigger;
 import org.pentaho.platform.api.scheduler2.IComplexJobTrigger;
 import org.pentaho.platform.api.scheduler2.IJobTrigger;
@@ -30,6 +31,8 @@ import org.pentaho.platform.api.scheduler2.ISimpleJobTrigger;
 import org.pentaho.platform.api.scheduler2.SimpleJobTrigger;
 import org.pentaho.platform.api.scheduler2.wrappers.DayOfMonthWrapper;
 import org.pentaho.platform.api.scheduler2.wrappers.DayOfWeekWrapper;
+import org.pentaho.platform.api.scheduler2.wrappers.HourlyWrapper;
+import org.pentaho.platform.api.scheduler2.wrappers.MinuteWrapper;
 import org.pentaho.platform.api.scheduler2.wrappers.MonthlyWrapper;
 import org.pentaho.platform.api.scheduler2.wrappers.YearlyWrapper;
 import org.pentaho.platform.api.util.IPdiContentProvider;
@@ -125,6 +128,15 @@ public class SchedulerResourceUtilTest {
     assertEquals( 1, (long) rec.getValues().get( 0 ) );
     rec = (RecurrenceList) recurrences.get( 1 );
     assertEquals( 25, (long) rec.getValues().get( 0 ) );
+    ComplexJobTrigger complexJobTrigger = (ComplexJobTrigger) trig;
+    HourlyWrapper hourlyWrapper = complexJobTrigger.getHourlyRecurrences();
+    assertEquals( 1, hourlyWrapper.getRecurrences().size() );
+    assertTrue( hourlyWrapper.getRecurrences().get( 0 ) instanceof RecurrenceList );
+    assertEquals( 0, (int) ( (RecurrenceList) hourlyWrapper.getRecurrences().get( 0 ) ).getValues().get( 0 ) );
+    MinuteWrapper minuteWrapper = complexJobTrigger.getMinuteRecurrences();
+    assertEquals( 1, minuteWrapper.getRecurrences().size() );
+    assertTrue( minuteWrapper.getRecurrences().get( 0 ) instanceof RecurrenceList );
+    assertEquals( 0, (int) ( (RecurrenceList) minuteWrapper.getRecurrences().get( 0 ) ).getValues().get( 0 ) );
   }
 
   @Test
@@ -144,6 +156,16 @@ public class SchedulerResourceUtilTest {
     assertEquals( 2, (long) rec.getValues().get( 0 ) );
     rec = (RecurrenceList) recurrences.get( 1 );
     assertEquals( 9, (long) rec.getValues().get( 0 ) );
+    ComplexJobTrigger complexJobTrigger = (ComplexJobTrigger) trig;
+    HourlyWrapper hourlyWrapper = complexJobTrigger.getHourlyRecurrences();
+    assertEquals( 1, hourlyWrapper.getRecurrences().size() );
+    assertTrue( hourlyWrapper.getRecurrences().get( 0 ) instanceof RecurrenceList );
+    assertEquals( 0, (int) ( (RecurrenceList) hourlyWrapper.getRecurrences().get( 0 ) ).getValues().get( 0 ) );
+    MinuteWrapper minuteWrapper = complexJobTrigger.getMinuteRecurrences();
+    assertEquals( 1, minuteWrapper.getRecurrences().size() );
+    assertTrue( minuteWrapper.getRecurrences().get( 0 ) instanceof RecurrenceList );
+    assertEquals( 0, (int) ( (RecurrenceList) minuteWrapper.getRecurrences().get( 0 ) ).getValues().get( 0 ) );
+    
   }
 
   @Test
@@ -163,6 +185,15 @@ public class SchedulerResourceUtilTest {
     assertEquals( 2016, (long) rec.getValues().get( 0 ) );
     rec = (RecurrenceList) recurrences.get( 1 );
     assertEquals( 2020, (long) rec.getValues().get( 0 ) );
+    ComplexJobTrigger complexJobTrigger = (ComplexJobTrigger) trig;
+    HourlyWrapper hourlyWrapper = complexJobTrigger.getHourlyRecurrences();
+    assertEquals( 1, hourlyWrapper.getRecurrences().size() );
+    assertTrue( hourlyWrapper.getRecurrences().get( 0 ) instanceof RecurrenceList );
+    assertEquals( 0, (int) ( (RecurrenceList) hourlyWrapper.getRecurrences().get( 0 ) ).getValues().get( 0 ) );
+    MinuteWrapper minuteWrapper = complexJobTrigger.getMinuteRecurrences();
+    assertEquals( 1, minuteWrapper.getRecurrences().size() );
+    assertTrue( minuteWrapper.getRecurrences().get( 0 ) instanceof RecurrenceList );
+    assertEquals( 0, (int) ( (RecurrenceList) minuteWrapper.getRecurrences().get( 0 ) ).getValues().get( 0 ) );
   }
 
   @Test
@@ -182,6 +213,15 @@ public class SchedulerResourceUtilTest {
     assertEquals( 2, (long) recurrence.getValues().get( 0 ) );
     recurrence = (RecurrenceList) recurrences.get( 1 );
     assertEquals( 6, (long) recurrence.getValues().get( 0 ) );
+    ComplexJobTrigger complexJobTrigger = (ComplexJobTrigger) trig;
+    HourlyWrapper hourlyWrapper = complexJobTrigger.getHourlyRecurrences();
+    assertEquals( 1, hourlyWrapper.getRecurrences().size() );
+    assertTrue( hourlyWrapper.getRecurrences().get( 0 ) instanceof RecurrenceList );
+    assertEquals( 0, (int) ( (RecurrenceList) hourlyWrapper.getRecurrences().get( 0 ) ).getValues().get( 0 ) );
+    MinuteWrapper minuteWrapper = complexJobTrigger.getMinuteRecurrences();
+    assertEquals( 1, minuteWrapper.getRecurrences().size() );
+    assertTrue( minuteWrapper.getRecurrences().get( 0 ) instanceof RecurrenceList );
+    assertEquals( 0, (int) ( (RecurrenceList) minuteWrapper.getRecurrences().get( 0 ) ).getValues().get( 0 ) );
   }
 
   @Test
@@ -214,6 +254,15 @@ public class SchedulerResourceUtilTest {
     rec = (QualifiedDayOfWeek) recurrences.get( 3 );
     assertEquals( "FRI", rec.getDayOfWeek().toString() );
     assertEquals( "LAST", rec.getQualifier().toString() );
+    ComplexJobTrigger complexJobTrigger = (ComplexJobTrigger) trig;
+    HourlyWrapper hourlyWrapper = complexJobTrigger.getHourlyRecurrences();
+    assertEquals( 1, hourlyWrapper.getRecurrences().size() );
+    assertTrue( hourlyWrapper.getRecurrences().get( 0 ) instanceof RecurrenceList );
+    assertEquals( 0, (int) ( (RecurrenceList) hourlyWrapper.getRecurrences().get( 0 ) ).getValues().get( 0 ) );
+    MinuteWrapper minuteWrapper = complexJobTrigger.getMinuteRecurrences();
+    assertEquals( 1, minuteWrapper.getRecurrences().size() );
+    assertTrue( minuteWrapper.getRecurrences().get( 0 ) instanceof RecurrenceList );
+    assertEquals( 0, (int) ( (RecurrenceList) minuteWrapper.getRecurrences().get( 0 ) ).getValues().get( 0 ) );
   }
 
   @Test
@@ -264,6 +313,15 @@ public class SchedulerResourceUtilTest {
     rec = (QualifiedDayOfWeek) recurrences.get( 3 );
     assertEquals( "FRI", rec.getDayOfWeek().toString() );
     assertEquals( "LAST", rec.getQualifier().toString() );
+    ComplexJobTrigger complexJobTrigger = (ComplexJobTrigger) trig;
+    HourlyWrapper hourlyWrapper = complexJobTrigger.getHourlyRecurrences();
+    assertEquals( 1, hourlyWrapper.getRecurrences().size() );
+    assertTrue( hourlyWrapper.getRecurrences().get( 0 ) instanceof RecurrenceList );
+    assertEquals( 16, (int) ( (RecurrenceList) hourlyWrapper.getRecurrences().get( 0 ) ).getValues().get( 0 ) );
+    MinuteWrapper minuteWrapper = complexJobTrigger.getMinuteRecurrences();
+    assertEquals( 1, minuteWrapper.getRecurrences().size() );
+    assertTrue( minuteWrapper.getRecurrences().get( 0 ) instanceof RecurrenceList );
+    assertEquals( 45, (int) ( (RecurrenceList) minuteWrapper.getRecurrences().get( 0 ) ).getValues().get( 0 ) );
 
   }
 


### PR DESCRIPTION
…eady

containing an entry for 0 minutes. This led to cron expressions being created with 2 minute entries, one on the hour and one at whatever start time was specified. Backport to 10.2 for 10.2.0.6 SP.