### PR TITLE
feat: move generic-file-service(-ee) to pentaho-platform [PPUC-124]

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -28,13 +28,13 @@
         <dependency>
             <groupId>pentaho</groupId>
             <artifactId>pentaho-generic-file-system-api</artifactId>
-            <version>${pentaho-generic-file-system.version}</version>
+            <version>${plugin-local-generic-file-system.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>pentaho</groupId>
             <artifactId>pentaho-generic-file-system-impl</artifactId>
-            <version>${pentaho-generic-file-system.version}</version>
+            <version>${plugin-local-generic-file-system.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>pentaho</groupId>
       <artifactId>pentaho-generic-file-system-api</artifactId>
-      <version>${pentaho-generic-file-system.version}</version>
+      <version>${plugin-local-generic-file-system.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <jmock.version>2.5.1</jmock.version>
     <mockito-core.version>4.0.0</mockito-core.version>
     <pentaho-scheduler-plugin.version>11.0.0.0-SNAPSHOT</pentaho-scheduler-plugin.version>
-    <pentaho-generic-file-system.version>1.0.0</pentaho-generic-file-system.version>
+    <plugin-local-generic-file-system.version>1.0.0</plugin-local-generic-file-system.version>
     <com.github.spotbugs.annotations.version>4.2.3</com.github.spotbugs.annotations.version>
     <platform.version>11.0.0.0-SNAPSHOT</platform.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>


### PR DESCRIPTION
- keep scheduler using local gfs 1.0.0, using a custom version property

To be merged with: https://github.com/pentaho/pentaho-scheduler-plugin-ee/pull/393