### PR TITLE
fix[BISERVER-15614]: Prevent misfire on resume

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -137,6 +137,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-tx</artifactId>
     </dependency>

--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -595,12 +595,7 @@ public class QuartzScheduler implements IScheduler {
    * @throws org.quartz.SchedulerException if there is an error accessing the scheduler
    */
   protected void saveExecutionDate( JobKey jobKey, Date executionTime ) throws org.quartz.SchedulerException {
-    jobDetailLock.writeLock().lock();
-    try {
-      normalizeTriggerTimingState( jobKey, executionTime );
-    } finally {
-      jobDetailLock.writeLock().unlock();
-    }
+    normalizeTriggerTimingState( jobKey, executionTime );
   }
 
   /**
@@ -621,41 +616,46 @@ public class QuartzScheduler implements IScheduler {
    * @throws org.quartz.SchedulerException if there is an error accessing the scheduler
    */
   private void normalizeTriggerTimingState( JobKey jobKey, Date executionTime ) throws org.quartz.SchedulerException {
-    JobDetail oldJobDetail = getJobDetail( jobKey );
-    if ( oldJobDetail == null ) {
-      return;
-    }
-
-    Trigger oldTrigger = getSingleJobTrigger( jobKey );
-    if ( oldTrigger == null ) {
-      return;
-    }
-
-    JobDataMap jobDataMap = new JobDataMap( oldJobDetail.getJobDataMap() );
-    if ( executionTime != null ) {
-      Object oldValue = jobDataMap.get( RESERVEDMAPKEY_LAST_EXECUTION_TIME );
-
-      // If the new execution time is before the currently stored execution time,
-      // do not update to ensure Last Run reflects the most recent execution
-      if ( oldValue instanceof Date && executionTime.before( (Date) oldValue ) ) {
+    jobDetailLock.writeLock().lock();
+    try {
+      JobDetail oldJobDetail = getJobDetail( jobKey );
+      if ( oldJobDetail == null ) {
         return;
       }
 
-      jobDataMap.put( RESERVEDMAPKEY_LAST_EXECUTION_TIME, executionTime );
+      Trigger oldTrigger = getSingleJobTrigger( jobKey );
+      if ( oldTrigger == null ) {
+        return;
+      }
+
+      JobDataMap jobDataMap = new JobDataMap( oldJobDetail.getJobDataMap() );
+      if ( executionTime != null ) {
+        Object oldValue = jobDataMap.get( RESERVEDMAPKEY_LAST_EXECUTION_TIME );
+
+        // If the new execution time is before the currently stored execution time,
+        // do not update to ensure Last Run reflects the most recent execution
+        if ( oldValue instanceof Date && executionTime.before( (Date) oldValue ) ) {
+          return;
+        }
+
+        jobDataMap.put( RESERVEDMAPKEY_LAST_EXECUTION_TIME, executionTime );
+      }
+
+      JobDetail newJobDetail = recreateJobDetail( oldJobDetail, jobKey, jobDataMap );
+      Trigger newTrigger = recreateTriggerWithNewStartTime( oldTrigger );
+
+      Scheduler scheduler = getQuartzScheduler();
+      Trigger.TriggerState oldTriggerState = scheduler.getTriggerState( oldTrigger.getKey() );
+
+      // Delete and reschedule the job to persist both the updated trigger timing state
+      // and any optional job data changes while preserving the original trigger state.
+      scheduler.deleteJob( jobKey );
+      scheduler.scheduleJob( newJobDetail, newTrigger );
+
+      restoreTriggerState( scheduler, oldTriggerState, newTrigger );
+    } finally {
+      jobDetailLock.writeLock().unlock();
     }
-
-    JobDetail newJobDetail = recreateJobDetail( oldJobDetail, jobKey, jobDataMap );
-    Trigger newTrigger = recreateTriggerWithNewStartTime( oldTrigger );
-
-    Scheduler scheduler = getQuartzScheduler();
-    Trigger.TriggerState oldTriggerState = scheduler.getTriggerState( oldTrigger.getKey() );
-
-    // Delete and reschedule the job to persist both the updated trigger timing state
-    // and any optional job data changes while preserving the original trigger state.
-    scheduler.deleteJob( jobKey );
-    scheduler.scheduleJob( newJobDetail, newTrigger );
-
-    restoreTriggerState( scheduler, oldTriggerState, newTrigger );
   }
 
   /**

--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -597,9 +597,42 @@ public class QuartzScheduler implements IScheduler {
   protected void saveExecutionDate( JobKey jobKey, Date executionTime ) throws org.quartz.SchedulerException {
     jobDetailLock.writeLock().lock();
     try {
-      JobDetail oldJobDetail = getJobDetail( jobKey );
+      normalizeTriggerTimingState( jobKey, executionTime );
+    } finally {
+      jobDetailLock.writeLock().unlock();
+    }
+  }
 
-      JobDataMap jobDataMap = oldJobDetail.getJobDataMap();
+  /**
+   * Rebuilds a job's trigger with a normalized start time and optionally updates the last execution timestamp
+   * in the job data map. This is necessary because Quartz's {@code CalendarIntervalTrigger} uses
+   * {@code MISFIRE_INSTRUCTION_FIRE_ONCE_NOW} by default, which causes the trigger to fire immediately
+   * whenever Quartz detects that {@code nextFireTime} is in the past. That happens after a paused schedule
+   * is resumed, or after the scheduler persists job data via delete-and-reschedule. Without rebuilding the
+   * trigger with a future start time, these operations would produce an unintended immediate execution.
+   *
+   * <p>The method deletes the existing job and reschedules it with a rebuilt {@link JobDetail} (carrying the
+   * potentially updated job data map) and a rebuilt trigger whose start time has been advanced to the next
+   * future fire time. The original trigger state (e.g. PAUSED) is restored after rescheduling.</p>
+   *
+   * @param jobKey the key identifying the job to normalize
+   * @param executionTime if non-null, the actual execution timestamp to store as the Last Run value;
+   *                      if null, the job data map is carried over without modification
+   * @throws org.quartz.SchedulerException if there is an error accessing the scheduler
+   */
+  private void normalizeTriggerTimingState( JobKey jobKey, Date executionTime ) throws org.quartz.SchedulerException {
+    JobDetail oldJobDetail = getJobDetail( jobKey );
+    if ( oldJobDetail == null ) {
+      return;
+    }
+
+    Trigger oldTrigger = getSingleJobTrigger( jobKey );
+    if ( oldTrigger == null ) {
+      return;
+    }
+
+    JobDataMap jobDataMap = new JobDataMap( oldJobDetail.getJobDataMap() );
+    if ( executionTime != null ) {
       Object oldValue = jobDataMap.get( RESERVEDMAPKEY_LAST_EXECUTION_TIME );
 
       // If the new execution time is before the currently stored execution time,
@@ -609,28 +642,45 @@ public class QuartzScheduler implements IScheduler {
       }
 
       jobDataMap.put( RESERVEDMAPKEY_LAST_EXECUTION_TIME, executionTime );
-
-      JobDetail newJobDetail = JobBuilder.newJob( oldJobDetail.getJobClass() )
-        .withIdentity( jobKey )
-        .usingJobData( jobDataMap )
-        .build();
-
-      Trigger oldTrigger = getSingleJobTrigger( jobKey );
-      Trigger newTrigger = recreateTriggerWithNewStartTime( oldTrigger );
-
-      // Capture the old trigger's state before deleting to preserve it on the new trigger
-      Scheduler scheduler = getQuartzScheduler();
-      Trigger.TriggerState oldTriggerState = scheduler.getTriggerState( oldTrigger.getKey() );
-
-      // Delete the old trigger and schedule the new one
-      // We cannot use addJob (update) since the JobDetail is not being stored durably, so it's immutable
-      scheduler.deleteJob( jobKey );
-      scheduler.scheduleJob( newJobDetail, newTrigger );
-
-      restoreTriggerState( scheduler, oldTriggerState, newTrigger );
-    } finally {
-      jobDetailLock.writeLock().unlock();
     }
+
+    JobDetail newJobDetail = recreateJobDetail( oldJobDetail, jobKey, jobDataMap );
+    Trigger newTrigger = recreateTriggerWithNewStartTime( oldTrigger );
+
+    Scheduler scheduler = getQuartzScheduler();
+    Trigger.TriggerState oldTriggerState = scheduler.getTriggerState( oldTrigger.getKey() );
+
+    // Delete and reschedule the job to persist both the updated trigger timing state
+    // and any optional job data changes while preserving the original trigger state.
+    scheduler.deleteJob( jobKey );
+    scheduler.scheduleJob( newJobDetail, newTrigger );
+
+    restoreTriggerState( scheduler, oldTriggerState, newTrigger );
+  }
+
+  /**
+   * Rebuilds a {@link JobDetail} preserving the original job class, identity, durability, recovery settings,
+   * and description, but with a new {@link JobDataMap}. This is needed because Quartz does not allow
+   * in-place mutation of a scheduled job's data map; the job must be deleted and rescheduled with a new
+   * {@link JobDetail} instance to persist changes such as the last execution timestamp.
+   *
+   * @param oldJobDetail the original job detail to copy settings from
+   * @param jobKey the job identity key
+   * @param jobDataMap the (potentially updated) job data map to attach to the new detail
+   * @return a new {@link JobDetail} with the same configuration but the provided data map
+   */
+  private JobDetail recreateJobDetail( JobDetail oldJobDetail, JobKey jobKey, JobDataMap jobDataMap ) {
+    JobBuilder jobBuilder = JobBuilder.newJob( oldJobDetail.getJobClass() )
+      .withIdentity( jobKey )
+      .usingJobData( jobDataMap )
+      .storeDurably( oldJobDetail.isDurable() )
+      .requestRecovery( oldJobDetail.requestsRecovery() );
+
+    if ( oldJobDetail.getDescription() != null ) {
+      jobBuilder.withDescription( oldJobDetail.getDescription() );
+    }
+
+    return jobBuilder.build();
   }
 
   /**
@@ -642,6 +692,7 @@ public class QuartzScheduler implements IScheduler {
    */
   private Trigger recreateTriggerWithNewStartTime( Trigger oldTrigger ) {
     Trigger newTrigger;
+    Date normalizedStartTime = determineNormalizedStartTime( oldTrigger );
 
     if ( oldTrigger instanceof CalendarIntervalTrigger calIntOldTrig ) {
       CalendarIntervalScheduleBuilder scheduleBuilder = CalendarIntervalScheduleBuilder.calendarIntervalSchedule()
@@ -654,15 +705,65 @@ public class QuartzScheduler implements IScheduler {
 
       newTrigger = calIntOldTrig.getTriggerBuilder()
         .withSchedule( scheduleBuilder )
-        .startAt( calIntOldTrig.getNextFireTime() )
+        .startAt( normalizedStartTime )
         .build();
     } else {
       newTrigger = oldTrigger.getTriggerBuilder()
-        .startAt( oldTrigger.getNextFireTime() )
+        .startAt( normalizedStartTime )
         .build();
     }
 
     return newTrigger;
+  }
+
+  /**
+   * Computes a start time for a rebuilt trigger that is guaranteed to be in the future whenever possible.
+   * This prevents Quartz's misfire logic from treating the rescheduled trigger as overdue and firing it
+   * immediately.
+   *
+   * <p>Resolution order:</p>
+   * <ol>
+   *   <li>If the trigger can compute a future fire time (via {@code getNextFireTimeInFuture}), use it.</li>
+   *   <li>If the trigger cannot compute a future time (e.g. it has ended), fall back to the stale
+   *       {@code nextFireTime}.</li>
+   *   <li>As a last resort, use the original {@code startTime}.</li>
+   * </ol>
+   *
+   * @param trigger the trigger whose timing is being normalized
+   * @return a {@link Date} to use as the start time for the rebuilt trigger
+   */
+  private Date determineNormalizedStartTime( Trigger trigger ) {
+    Date futureFireTime = getNextFireTimeInFuture( trigger );
+    if ( futureFireTime != null ) {
+      return futureFireTime;
+    }
+
+    Date nextFireTime = trigger.getNextFireTime();
+    if ( nextFireTime != null ) {
+      return nextFireTime;
+    }
+
+    return trigger.getStartTime();
+  }
+
+  /**
+   * Returns the next fire time in the future for a trigger, or null if no future fire time exists.
+   * If the current {@code nextFireTime} is already in the future, returns it directly; otherwise,
+   * computes the next fire time after <em>now</em> using the trigger's interval/schedule.
+   *
+   * @param trigger the trigger to compute the next fire time for
+   * @return a future fire time, or null if the trigger cannot compute a future time
+   */
+  private Date getNextFireTimeInFuture( Trigger trigger ) {
+    Date nextFireTime = trigger.getNextFireTime();
+    if ( nextFireTime == null ) {
+      return null;
+    }
+
+    Date now = new Date();
+    return nextFireTime.after( now )
+      ? nextFireTime
+      : trigger.getFireTimeAfter( now );
   }
 
   /**
@@ -844,12 +945,7 @@ public class QuartzScheduler implements IScheduler {
   }
 
   protected void setJobNextRun( Job job, Trigger trigger ) {
-    //if getNextFireTime() is in the future, then we use it
-    //if it is in the past, we call getFireTimeAfter( new Date() ) to get the correct next date from today on
-    Date nextFire = trigger.getNextFireTime();
-    job.setNextRun( nextFire != null && ( nextFire.getTime() < new Date().getTime() )
-      ? trigger.getFireTimeAfter( new Date() )
-      : nextFire );
+    job.setNextRun( getNextFireTimeInFuture( trigger ) );
   }
 
   private void setJobTrigger( Scheduler scheduler, Job job, Trigger trigger ) throws SchedulerException,
@@ -1075,7 +1171,9 @@ public class QuartzScheduler implements IScheduler {
   public void resumeJob( String jobId ) throws SchedulerException {
     try {
       Scheduler scheduler = getQuartzScheduler();
-      scheduler.resumeJob( new JobKey( jobId, QuartzJobKey.parse( jobId ).getUserName() ) );
+      JobKey jobKey = new JobKey( jobId, QuartzJobKey.parse( jobId ).getUserName() );
+      normalizeTriggerTimingState( jobKey, null );
+      scheduler.resumeJob( jobKey );
     } catch ( org.quartz.SchedulerException e ) {
       throw new SchedulerException( Messages.getString(
         QUARTZ_SCHEDULER_ERROR_0005_FAILED_TO_RESUME_JOBS ), e );

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
@@ -31,6 +31,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.awaitility.Awaitility.await;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -434,7 +436,12 @@ public class QuartzSchedulerSaveExecutionDateTest {
     quartzScheduler.triggerNow( jobKey.getName() );
 
     assertTrue( "Execute Now should fire the job once", CountingJob.awaitExecution() );
-    assertNoAdditionalExecution( "Execute Now should produce a single execution" );
+
+    await()
+      .pollInterval( 50, TimeUnit.MILLISECONDS )
+      .during( 750, TimeUnit.MILLISECONDS )
+      .atMost( 1, TimeUnit.SECONDS )
+      .until( () -> CountingJob.getExecutionCount() <= 1 );
 
     assertEquals( "Execute Now should produce a single execution", 1, CountingJob.getExecutionCount() );
     assertEquals( "Execute Now should not pre-update Last Run", lastExecutionTime,
@@ -479,26 +486,15 @@ public class QuartzSchedulerSaveExecutionDateTest {
 
     quartzScheduler.resumeJob( jobKey.getName() );
 
-    assertNoAdditionalExecution( "Resume should not immediately execute a paused schedule" );
+    await()
+      .pollInterval( 50, TimeUnit.MILLISECONDS )
+      .during( 750, TimeUnit.MILLISECONDS )
+      .atMost( 1, TimeUnit.SECONDS )
+      .until( () -> CountingJob.getExecutionCount() == 0 );
 
     assertEquals( "Resume should not immediately execute a paused schedule", 0, CountingJob.getExecutionCount() );
     assertEquals( "Resume should not pre-update Last Run", lastExecutionTime,
       scheduler.getJobDetail( jobKey ).getJobDataMap().get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
-  }
-
-  /**
-   * Polls for a bounded period to verify no additional job execution occurs.
-   * Fails fast if an unexpected execution is detected instead of relying on a fixed sleep.
-   */
-  private void assertNoAdditionalExecution( String message ) throws InterruptedException {
-    int baseline = CountingJob.getExecutionCount();
-    long deadline = System.currentTimeMillis() + 750;
-    while ( System.currentTimeMillis() < deadline ) {
-      if ( CountingJob.getExecutionCount() > baseline ) {
-        fail( message );
-      }
-      Thread.sleep( 50 );
-    }
   }
 
   private boolean isManualTrigger( Trigger trigger ) {

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
@@ -53,7 +53,6 @@ public class QuartzSchedulerSaveExecutionDateTest {
   private static final String MOCK_TEST_GROUP = "test-group";
   private static final String PARAM_KEY = "key1";
   private static final String UTC_TIMEZONE = "UTC";
-  private static final String MANUAL_TRIGGER_PREFIX = "MT_";
   private static final String MOCK_CALENDAR_NAME = "my-calendar";
   private static final String CRON_CALENDAR_NAME = "cron-calendar";
   private static final int EXECUTION_TIMEOUT_SECONDS = 5;
@@ -228,7 +227,7 @@ public class QuartzSchedulerSaveExecutionDateTest {
 
     // Assert: Verify calendar name is preserved on new trigger
     Trigger newTrigger = scheduler.getTriggersOfJob( jobKey ).stream()
-      .filter( t -> !t.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX ) )
+      .filter( t -> !quartzScheduler.isManualTrigger( t ) )
       .findFirst()
       .orElse( null );
 
@@ -266,7 +265,7 @@ public class QuartzSchedulerSaveExecutionDateTest {
 
     // Assert: Verify calendar name remains null
     Trigger newTrigger = scheduler.getTriggersOfJob( jobKey ).stream()
-      .filter( t -> !t.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX ) )
+      .filter( t -> !quartzScheduler.isManualTrigger( t ) )
       .findFirst()
       .orElse( null );
 
@@ -304,7 +303,7 @@ public class QuartzSchedulerSaveExecutionDateTest {
 
     // Assert: Verify schedule properties are preserved
     Trigger newTrigger = scheduler.getTriggersOfJob( jobKey ).stream()
-      .filter( t -> !t.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX ) )
+      .filter( t -> !quartzScheduler.isManualTrigger( t ) )
       .findFirst( )
       .orElse( null );
 
@@ -352,7 +351,7 @@ public class QuartzSchedulerSaveExecutionDateTest {
 
     // Assert: Verify calendar name is preserved for CronTrigger
     Trigger newTrigger = scheduler.getTriggersOfJob( jobKey ).stream()
-      .filter( t -> !t.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX ) )
+      .filter( t -> !quartzScheduler.isManualTrigger( t ) )
       .findFirst( )
       .orElse( null );
 
@@ -396,7 +395,7 @@ public class QuartzSchedulerSaveExecutionDateTest {
 
     // Assert: Get the new trigger and verify it's still paused
     Trigger newTrigger = scheduler.getTriggersOfJob( jobKey ).stream()
-      .filter( t -> !t.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX ) )
+      .filter( t -> !quartzScheduler.isManualTrigger( t ) )
       .findFirst()
       .orElse( null );
 
@@ -448,7 +447,7 @@ public class QuartzSchedulerSaveExecutionDateTest {
       scheduler.getJobDetail( jobKey ).getJobDataMap().get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
 
     long manualTriggerCount = scheduler.getTriggersOfJob( jobKey ).stream()
-      .filter( this::isManualTrigger )
+      .filter( quartzScheduler::isManualTrigger )
       .count();
     assertTrue( "Manual trigger handling should remain intact", manualTriggerCount <= 1 );
   }
@@ -504,10 +503,4 @@ public class QuartzSchedulerSaveExecutionDateTest {
       scheduler.getJobDetail( jobKey ).getJobDataMap().get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
   }
 
-  private boolean isManualTrigger( Trigger trigger ) {
-    return trigger != null
-      && trigger.getKey() != null
-      && trigger.getKey().getName() != null
-      && trigger.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX );
-  }
 }

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
@@ -10,6 +10,7 @@ import org.quartz.DateBuilder;
 import org.quartz.JobBuilder;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
 import org.quartz.JobKey;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerFactory;
@@ -25,6 +26,10 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -49,15 +54,41 @@ public class QuartzSchedulerSaveExecutionDateTest {
   private static final String MANUAL_TRIGGER_PREFIX = "MT_";
   private static final String MOCK_CALENDAR_NAME = "my-calendar";
   private static final String CRON_CALENDAR_NAME = "cron-calendar";
+  private static final int EXECUTION_TIMEOUT_SECONDS = 5;
 
   private Scheduler scheduler;
   private QuartzScheduler quartzScheduler;
+
+  public static class CountingJob implements org.quartz.Job {
+    private static final AtomicInteger EXECUTIONS = new AtomicInteger();
+    private static final AtomicReference<CountDownLatch> LATCH = new AtomicReference<>( new CountDownLatch( 1 ) );
+
+    static void reset() {
+      EXECUTIONS.set( 0 );
+      LATCH.set( new CountDownLatch( 1 ) );
+    }
+
+    static int getExecutionCount() {
+      return EXECUTIONS.get();
+    }
+
+    static boolean awaitExecution() throws InterruptedException {
+      return LATCH.get().await( EXECUTION_TIMEOUT_SECONDS, TimeUnit.SECONDS );
+    }
+
+    @Override
+    public void execute( JobExecutionContext context ) {
+      EXECUTIONS.incrementAndGet();
+      LATCH.get().countDown();
+    }
+  }
 
   @Before
   public void setUp() throws Exception {
     scheduler = new StdSchedulerFactory().getScheduler();
     scheduler.start();
     quartzScheduler = new QuartzScheduler();
+    CountingJob.reset();
   }
 
   @After
@@ -102,9 +133,12 @@ public class QuartzSchedulerSaveExecutionDateTest {
     mockQuartzScheduler.saveExecutionDate( jobKey, executionTime );
 
     // Assert
-    assertEquals( executionTime, jobDataMap.get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
     verify( mockScheduler ).deleteJob( jobKey );
-    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), any( Trigger.class ) );
+
+    ArgumentCaptor<JobDetail> jobDetailCaptor = ArgumentCaptor.forClass( JobDetail.class );
+    verify( mockScheduler ).scheduleJob( jobDetailCaptor.capture(), any( Trigger.class ) );
+    assertEquals( executionTime,
+      jobDetailCaptor.getValue().getJobDataMap().get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
   }
 
   @Test
@@ -144,11 +178,13 @@ public class QuartzSchedulerSaveExecutionDateTest {
 
     mockQuartzScheduler.saveExecutionDate( jobKey, executionTime );
 
-    assertEquals( executionTime, jobDataMap.get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
     verify( mockScheduler ).deleteJob( jobKey );
 
+    ArgumentCaptor<JobDetail> jobDetailCaptor = ArgumentCaptor.forClass( JobDetail.class );
     ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass( Trigger.class );
-    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), triggerCaptor.capture() );
+    verify( mockScheduler ).scheduleJob( jobDetailCaptor.capture(), triggerCaptor.capture() );
+    assertEquals( executionTime,
+      jobDetailCaptor.getValue().getJobDataMap().get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
     Trigger scheduledTrigger = triggerCaptor.getValue();
     assertTrue( scheduledTrigger instanceof CalendarIntervalTriggerImpl );
     CalendarIntervalTriggerImpl t = (CalendarIntervalTriggerImpl) scheduledTrigger;
@@ -365,5 +401,95 @@ public class QuartzSchedulerSaveExecutionDateTest {
     assertNotNull( TRIGGER_EXISTS_MESSAGE, newTrigger );
     assertEquals( "New trigger should be PAUSED after saveExecutionDate", Trigger.TriggerState.PAUSED,
       scheduler.getTriggerState( newTrigger.getKey() ) );
+  }
+
+  @Test
+  public void testTriggerNowExecutesCalendarIntervalJobExactlyOnce() throws Exception {
+    QuartzJobKey quartzJobKey = new QuartzJobKey( TEST_JOB, TEST_GROUP );
+    JobKey jobKey = new JobKey( quartzJobKey.toString(), quartzJobKey.getUserName() );
+    Date lastExecutionTime = new Date( System.currentTimeMillis() - 10_000 );
+
+    JobDataMap jobDataMap = new JobDataMap();
+    jobDataMap.put( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME, lastExecutionTime );
+
+    JobDetail jobDetail = JobBuilder.newJob( CountingJob.class )
+      .withIdentity( jobKey )
+      .usingJobData( jobDataMap )
+      .build();
+
+    CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl();
+    trigger.setKey( new TriggerKey( TEST_TRIGGER, TEST_GROUP ) );
+    trigger.setJobKey( jobKey );
+    trigger.setRepeatInterval( 1 );
+    trigger.setRepeatIntervalUnit( DateBuilder.IntervalUnit.HOUR );
+    trigger.setStartTime( new Date( System.currentTimeMillis() + 60_000 ) );
+    trigger.setMisfireInstruction( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_FIRE_ONCE_NOW );
+
+    scheduler.scheduleJob( jobDetail, trigger );
+
+    SchedulerFactory schedulerFactory = mock( SchedulerFactory.class );
+    when( schedulerFactory.getScheduler() ).thenReturn( scheduler );
+    quartzScheduler.setQuartzSchedulerFactory( schedulerFactory );
+
+    quartzScheduler.triggerNow( jobKey.getName() );
+
+    assertTrue( "Execute Now should fire the job once", CountingJob.awaitExecution() );
+    Thread.sleep( 500 );
+
+    assertEquals( "Execute Now should produce a single execution", 1, CountingJob.getExecutionCount() );
+    assertEquals( "Execute Now should not pre-update Last Run", lastExecutionTime,
+      scheduler.getJobDetail( jobKey ).getJobDataMap().get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
+
+    long manualTriggerCount = scheduler.getTriggersOfJob( jobKey ).stream()
+      .filter( this::isManualTrigger )
+      .count();
+    assertTrue( "Manual trigger handling should remain intact", manualTriggerCount <= 1 );
+  }
+
+  @Test
+  public void testResumeJobDoesNotImmediatelyFirePausedCalendarIntervalSchedule() throws Exception {
+    QuartzJobKey quartzJobKey = new QuartzJobKey( TEST_JOB, TEST_GROUP );
+    JobKey jobKey = new JobKey( quartzJobKey.toString(), quartzJobKey.getUserName() );
+    Date lastExecutionTime = new Date( System.currentTimeMillis() - 10_000 );
+
+    JobDataMap jobDataMap = new JobDataMap();
+    jobDataMap.put( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME, lastExecutionTime );
+
+    JobDetail jobDetail = JobBuilder.newJob( CountingJob.class )
+      .withIdentity( jobKey )
+      .usingJobData( jobDataMap )
+      .build();
+
+    CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl();
+    trigger.setKey( new TriggerKey( TEST_TRIGGER, TEST_GROUP ) );
+    trigger.setJobKey( jobKey );
+    trigger.setRepeatInterval( 1 );
+    trigger.setRepeatIntervalUnit( DateBuilder.IntervalUnit.MINUTE );
+    trigger.setStartTime( new Date( System.currentTimeMillis() + 1_000 ) );
+    trigger.setMisfireInstruction( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_FIRE_ONCE_NOW );
+
+    scheduler.scheduleJob( jobDetail, trigger );
+    scheduler.pauseJob( jobKey );
+
+    Thread.sleep( 2_500 );
+
+    SchedulerFactory schedulerFactory = mock( SchedulerFactory.class );
+    when( schedulerFactory.getScheduler() ).thenReturn( scheduler );
+    quartzScheduler.setQuartzSchedulerFactory( schedulerFactory );
+
+    quartzScheduler.resumeJob( jobKey.getName() );
+
+    Thread.sleep( 750 );
+
+    assertEquals( "Resume should not immediately execute a paused schedule", 0, CountingJob.getExecutionCount() );
+    assertEquals( "Resume should not pre-update Last Run", lastExecutionTime,
+      scheduler.getJobDetail( jobKey ).getJobDataMap().get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
+  }
+
+  private boolean isManualTrigger( Trigger trigger ) {
+    return trigger != null
+      && trigger.getKey() != null
+      && trigger.getKey().getName() != null
+      && trigger.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX );
   }
 }

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
@@ -434,7 +434,7 @@ public class QuartzSchedulerSaveExecutionDateTest {
     quartzScheduler.triggerNow( jobKey.getName() );
 
     assertTrue( "Execute Now should fire the job once", CountingJob.awaitExecution() );
-    Thread.sleep( 500 );
+    assertNoAdditionalExecution( "Execute Now should produce a single execution" );
 
     assertEquals( "Execute Now should produce a single execution", 1, CountingJob.getExecutionCount() );
     assertEquals( "Execute Now should not pre-update Last Run", lastExecutionTime,
@@ -479,11 +479,26 @@ public class QuartzSchedulerSaveExecutionDateTest {
 
     quartzScheduler.resumeJob( jobKey.getName() );
 
-    Thread.sleep( 750 );
+    assertNoAdditionalExecution( "Resume should not immediately execute a paused schedule" );
 
     assertEquals( "Resume should not immediately execute a paused schedule", 0, CountingJob.getExecutionCount() );
     assertEquals( "Resume should not pre-update Last Run", lastExecutionTime,
       scheduler.getJobDetail( jobKey ).getJobDataMap().get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
+  }
+
+  /**
+   * Polls for a bounded period to verify no additional job execution occurs.
+   * Fails fast if an unexpected execution is detected instead of relying on a fixed sleep.
+   */
+  private void assertNoAdditionalExecution( String message ) throws InterruptedException {
+    int baseline = CountingJob.getExecutionCount();
+    long deadline = System.currentTimeMillis() + 750;
+    while ( System.currentTimeMillis() < deadline ) {
+      if ( CountingJob.getExecutionCount() > baseline ) {
+        fail( message );
+      }
+      Thread.sleep( 50 );
+    }
   }
 
   private boolean isManualTrigger( Trigger trigger ) {

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
@@ -478,7 +478,14 @@ public class QuartzSchedulerSaveExecutionDateTest {
     scheduler.scheduleJob( jobDetail, trigger );
     scheduler.pauseJob( jobKey );
 
-    Thread.sleep( 2_500 );
+    // Wait until the trigger's nextFireTime has lapsed so Quartz would normally misfire on resume
+    await()
+      .pollInterval( 100, TimeUnit.MILLISECONDS )
+      .atMost( 5, TimeUnit.SECONDS )
+      .until( () -> {
+        Trigger t = scheduler.getTriggersOfJob( jobKey ).stream().findFirst().orElse( null );
+        return t != null && t.getNextFireTime() != null && t.getNextFireTime().before( new Date() );
+      } );
 
     SchedulerFactory schedulerFactory = mock( SchedulerFactory.class );
     when( schedulerFactory.getScheduler() ).thenReturn( scheduler );

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
@@ -57,7 +57,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -423,7 +422,7 @@ public class QuartzSchedulerTest {
 
     // Mock Scheduler and related objects
     Scheduler mockScheduler = mock( Scheduler.class );
-    
+
     // Mock SchedulerFactory
     SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
 

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
@@ -57,13 +57,17 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.pentaho.platform.api.scheduler2.IScheduler.RESERVEDMAPKEY_ACTIONUSER;
 
 public class QuartzSchedulerTest {
+
+  private static final String TEST_CRON_EXPRESSION = "0 0/5 * * * ?";
+  private static final String TEST_JOB_ID = "testJob\ttestGroup\trandomUuid";
+  private static final String TEST_JOB_GROUP = "testJob";
 
 
   private static IUnifiedRepository repo;
@@ -393,7 +397,7 @@ public class QuartzSchedulerTest {
   public void testCreateQuartzTriggerWithComplexJobTrigger() throws Exception {
     // Arrange
     ComplexJobTrigger complexTrigger = new ComplexJobTrigger();
-    complexTrigger.setCronString( "0 0/5 * * * ?" );
+    complexTrigger.setCronString( TEST_CRON_EXPRESSION );
 
     QuartzJobKey jobKey = new QuartzJobKey( "testJob", "testUser" );
 
@@ -403,7 +407,7 @@ public class QuartzSchedulerTest {
     // Assert
     assertNotNull( quartzTrigger );
     assertTrue( quartzTrigger instanceof CronTriggerImpl );
-    assertEquals( "0 0/5 * * * ?", ((CronTriggerImpl) quartzTrigger).getCronExpression() );
+    assertEquals( TEST_CRON_EXPRESSION, ((CronTriggerImpl) quartzTrigger).getCronExpression() );
   }
 
   @Test
@@ -411,7 +415,7 @@ public class QuartzSchedulerTest {
     // Arrange
     // Mock JobDetail and related objects
     JobDetail mockJobDetail = mock( JobDetail.class );
-    JobKey jobKey = new JobKey( "testJob\ttestGroup\trandomUuid", "testJob" );
+    JobKey jobKey = new JobKey( TEST_JOB_ID, TEST_JOB_GROUP );
     JobDataMap jobDataMap = new JobDataMap();
 
     when( mockJobDetail.getKey() ).thenReturn( jobKey );
@@ -430,7 +434,7 @@ public class QuartzSchedulerTest {
     quartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
 
     // Act
-    quartzScheduler.triggerNow( "testJob\ttestGroup\trandomUuid" );
+    quartzScheduler.triggerNow( TEST_JOB_ID );
 
     // Assert
     // Verify that triggerJob is called (the actual execution timestamp
@@ -438,12 +442,103 @@ public class QuartzSchedulerTest {
     verify( mockScheduler ).triggerJob( jobKey );
   }
 
+
+
+  @Test
+  public void testResumeJobNormalizesPastCalendarIntervalTriggerToFutureFireTime() throws Exception {
+    JobKey jobKey = new JobKey( TEST_JOB_ID, TEST_JOB_GROUP );
+    JobDataMap jobDataMap = new JobDataMap();
+
+    JobDetail mockJobDetail = mock( JobDetail.class );
+    when( mockJobDetail.getKey() ).thenReturn( jobKey );
+    when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
+    when( mockJobDetail.getJobClass() ).thenReturn( (Class) BlockingQuartzJob.class );
+    when( mockJobDetail.isDurable() ).thenReturn( false );
+    when( mockJobDetail.requestsRecovery() ).thenReturn( false );
+
+    // Start time 3 minutes in the past, interval 2 minutes → nextFireTime is stale (in the past),
+    // but getFireTimeAfter(now) will compute a future time based on the interval.
+    CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl();
+    trigger.setKey( new TriggerKey( "scheduled-trigger", jobKey.getGroup() ) );
+    trigger.setJobKey( jobKey );
+    trigger.setStartTime( new Date( System.currentTimeMillis() - 180_000 ) );
+    trigger.setNextFireTime( new Date( System.currentTimeMillis() - 60_000 ) );
+    trigger.setRepeatInterval( 2 );
+    trigger.setRepeatIntervalUnit( DateBuilder.IntervalUnit.MINUTE );
+    trigger.setMisfireInstruction( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_FIRE_ONCE_NOW );
+    trigger.setTimeZone( TimeZone.getTimeZone( "UTC" ) );
+
+    Scheduler mockScheduler = mock( Scheduler.class );
+    when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
+    when( mockScheduler.getTriggersOfJob( jobKey ) ).thenAnswer( unused -> Collections.singletonList( trigger ) );
+    when( mockScheduler.getTriggerState( trigger.getKey() ) ).thenReturn( Trigger.TriggerState.PAUSED );
+
+    SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
+    when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
+
+    QuartzScheduler quartzScheduler = new QuartzScheduler();
+    quartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
+
+    quartzScheduler.resumeJob( TEST_JOB_ID );
+
+    ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass( Trigger.class );
+    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), triggerCaptor.capture() );
+    verify( mockScheduler ).pauseTrigger( triggerCaptor.getValue().getKey() );
+    verify( mockScheduler ).resumeJob( jobKey );
+
+    assertTrue( triggerCaptor.getValue() instanceof CalendarIntervalTrigger );
+    assertTrue( "Normalized start time should be in the future",
+      triggerCaptor.getValue().getStartTime().after( new Date() ) );
+  }
+
+  @Test
+  public void testResumeJobPreservesCronTriggerCalendarName() throws Exception {
+    JobKey jobKey = new JobKey( TEST_JOB_ID, TEST_JOB_GROUP );
+    JobDataMap jobDataMap = new JobDataMap();
+
+    JobDetail mockJobDetail = mock( JobDetail.class );
+    when( mockJobDetail.getKey() ).thenReturn( jobKey );
+    when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
+    when( mockJobDetail.getJobClass() ).thenReturn( (Class) BlockingQuartzJob.class );
+    when( mockJobDetail.isDurable() ).thenReturn( false );
+    when( mockJobDetail.requestsRecovery() ).thenReturn( false );
+
+    CronTriggerImpl trigger = new CronTriggerImpl();
+    trigger.setKey( new TriggerKey( "cron-trigger", jobKey.getGroup() ) );
+    trigger.setJobKey( jobKey );
+    trigger.setStartTime( new Date( System.currentTimeMillis() - 1_000 ) );
+    trigger.setNextFireTime( new Date( System.currentTimeMillis() + 60_000 ) );
+    trigger.setCalendarName( "cron-calendar" );
+    trigger.setCronExpression( TEST_CRON_EXPRESSION );
+
+    Scheduler mockScheduler = mock( Scheduler.class );
+    when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
+    when( mockScheduler.getTriggersOfJob( jobKey ) ).thenAnswer( unused -> Collections.singletonList( trigger ) );
+    when( mockScheduler.getTriggerState( trigger.getKey() ) ).thenReturn( Trigger.TriggerState.PAUSED );
+
+    SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
+    when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
+
+    QuartzScheduler quartzScheduler = new QuartzScheduler();
+    quartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
+
+    quartzScheduler.resumeJob( TEST_JOB_ID );
+
+    ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass( Trigger.class );
+    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), triggerCaptor.capture() );
+    verify( mockScheduler ).resumeJob( jobKey );
+    assertTrue( triggerCaptor.getValue() instanceof CronTrigger );
+    assertEquals( trigger.getCalendarName(), triggerCaptor.getValue().getCalendarName() );
+  }
+
+
+
   @Test
   public void testGetLastRun_ReturnsNull() throws Exception {
     // Arrange
     // Test that when no LAST_EXECUTION_TIME is present, the method returns null
     JobDetail mockJobDetail = mock( JobDetail.class );
-    JobKey jobKey = new JobKey( "testJob\ttestGroup\trandomUuid", "testJob" );
+    JobKey jobKey = new JobKey( TEST_JOB_ID, TEST_JOB_GROUP );
     JobDataMap jobDataMap = new JobDataMap();
 
     when( mockJobDetail.getKey() ).thenReturn( jobKey );
@@ -479,7 +574,7 @@ public class QuartzSchedulerTest {
     Date lastExecutionTime = new Date( System.currentTimeMillis() - 500 );
 
     JobDetail mockJobDetail = mock( JobDetail.class );
-    JobKey jobKey = new JobKey( "testJob\ttestGroup\trandomUuid", "testJob" );
+    JobKey jobKey = new JobKey( TEST_JOB_ID, TEST_JOB_GROUP );
     JobDataMap jobDataMap = new JobDataMap();
     jobDataMap.put( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME, lastExecutionTime );
 
@@ -511,7 +606,7 @@ public class QuartzSchedulerTest {
   @Test
   public void testGetJob_WithSimpleTrigger_MapsSimpleJobTriggerFields() throws Exception {
     // Arrange
-    String jobId = "testJob\ttestGroup\trandomUuid";
+    String jobId = TEST_JOB_ID;
     JobKey quartzJobKey = new JobKey( jobId, "testJob" );
     Date startTime = new Date( 125, Calendar.APRIL, 17, 14, 23, 0 );
     Date endTime = new Date( 125, Calendar.APRIL, 20, 9, 45, 0 );


### PR DESCRIPTION
### Problem
An issue in the Pentaho Scheduler Plugin causes immediate job execution when a paused schedule is resumed. This happens because:

1. When a trigger is paused, its `nextFireTime` remains stale (in the past) and is not updated by Quartz
2. Upon resume, the scheduler moves the paused trigger back to WAITING state
3. Quartz detects that `nextFireTime` is in the past and applies the trigger's misfire instruction
4. `CalendarIntervalTrigger` uses `MISFIRE_INSTRUCTION_FIRE_ONCE_NOW` by default, which fires the job immediately as a "catch-up" mechanism
5. Result: An unintended immediate execution of the job

### Solution
Before resuming or rescheduling a job, normalize the trigger's timing state by:

1. **Computing a future start time** using `getNextFireTimeInFuture()`:
   - If `nextFireTime` is already in the future, use it
   - Otherwise, compute the next fire time after *now* using the trigger's interval/schedule
   - As a fallback, use the stale `nextFireTime` or original `startTime`

2. **Rebuilding the trigger** with the normalized start time while preserving all original properties (interval, timezone, DST settings, misfire instruction, calendar name)

3. **Recreating the JobDetail** to persist any updated job data (e.g., Last Run timestamp) via Quartz's delete-and-reschedule mechanism

4. **Restoring the trigger state** (e.g., paused) after rescheduling

### Changes Made
- **`getNextFireTimeInFuture(Trigger)`**: Shared helper that computes a future start time using resolution order: future nextFireTime → computed getFireTimeAfter(now) → fallback to stale nextFireTime or startTime. Prevents misfire from treating rescheduled triggers as overdue.
- **`normalizeTriggerTimingState(JobKey, Date)`**: Central method that orchestrates trigger/job rebuild with normalized timing, deletes old trigger, reschedules with new timing, and restores trigger state
- **`recreateTriggerWithNewStartTime(Trigger)`**: Rebuilds the trigger with normalized start time from `getNextFireTimeInFuture()`, preserving all properties
- **`recreateJobDetail(JobDetail, JobKey, JobDataMap)`**: Creates a new JobDetail with the updated job data map
- **`applyMisfireInstruction()` & `restoreTriggerState()`**: Helper methods for misfire handling and state preservation
- **`resumeJob()` integration**: Calls `normalizeTriggerTimingState()` before resuming to ensure no immediate execution
- **`saveExecutionDate()` refactoring**: Uses the shared `normalizeTriggerTimingState()` to persist Last Run timestamps
- **`setJobNextRun()` simplification**: Refactored to use `getNextFireTimeInFuture()` for consistent timing logic

### Testing
- Unit tests verify trigger normalization, state preservation, calendar name handling and that resumed paused schedules do NOT immediately execute
- All 33 tests pass in `QuartzSchedulerTest` and `QuartzSchedulerSaveExecutionDateTest`
