### PR TITLE
fix[BISERVER-15614]: Prevent infinite loop on run-once/end-dated schedule rescheduling

### DIFF
--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -643,6 +643,12 @@ public class QuartzScheduler implements IScheduler {
 
       JobDetail newJobDetail = recreateJobDetail( oldJobDetail, jobKey, jobDataMap );
       Trigger newTrigger = recreateTriggerWithNewStartTime( oldTrigger );
+      if ( newTrigger == null ) {
+        // The trigger has no future fire time (e.g. run-once or end-dated schedule whose lifecycle
+        // is complete). Rescheduling with a past startTime would cause an immediate misfire execution
+        // and an infinite loop, so normalization is skipped.
+        return;
+      }
 
       Scheduler scheduler = getQuartzScheduler();
       Trigger.TriggerState oldTriggerState = scheduler.getTriggerState( oldTrigger.getKey() );
@@ -684,15 +690,24 @@ public class QuartzScheduler implements IScheduler {
   }
 
   /**
-   * Recreates a trigger with the same properties as the old one, but with the new start time
+   * Recreates a trigger with the same properties as the old one, but with a normalized start time
    * to avoid duplicated executions due to misfire instructions.
    *
+   * <p>Returns {@code null} when the trigger has no future fire time — for example, a run-once
+   * schedule or a job whose {@code endTime} has already lapsed. In that case the caller must
+   * <em>not</em> reschedule the trigger; doing so with a past {@code startTime} combined with
+   * {@code MISFIRE_INSTRUCTION_FIRE_ONCE_NOW} would produce an immediate execution and an
+   * infinite rescheduling loop.</p>
+   *
    * @param oldTrigger the trigger to recreate
-   * @return a new trigger with updated start time, preserving original properties
+   * @return a new trigger with an updated start time preserving original properties,
+   *         or {@code null} if the trigger has no future fire times
    */
   private Trigger recreateTriggerWithNewStartTime( Trigger oldTrigger ) {
-    Trigger newTrigger;
-    Date normalizedStartTime = determineNormalizedStartTime( oldTrigger );
+    Date normalizedStartTime = getNextFireTimeInFuture( oldTrigger );
+    if ( normalizedStartTime == null ) {
+      return null;
+    }
 
     if ( oldTrigger instanceof CalendarIntervalTrigger calIntOldTrig ) {
       CalendarIntervalScheduleBuilder scheduleBuilder = CalendarIntervalScheduleBuilder.calendarIntervalSchedule()
@@ -703,47 +718,15 @@ public class QuartzScheduler implements IScheduler {
 
       scheduleBuilder = applyMisfireInstruction( scheduleBuilder, calIntOldTrig.getMisfireInstruction() );
 
-      newTrigger = calIntOldTrig.getTriggerBuilder()
+      return calIntOldTrig.getTriggerBuilder()
         .withSchedule( scheduleBuilder )
         .startAt( normalizedStartTime )
         .build();
     } else {
-      newTrigger = oldTrigger.getTriggerBuilder()
+      return oldTrigger.getTriggerBuilder()
         .startAt( normalizedStartTime )
         .build();
     }
-
-    return newTrigger;
-  }
-
-  /**
-   * Computes a start time for a rebuilt trigger that is guaranteed to be in the future whenever possible.
-   * This prevents Quartz's misfire logic from treating the rescheduled trigger as overdue and firing it
-   * immediately.
-   *
-   * <p>Resolution order:</p>
-   * <ol>
-   *   <li>If the trigger can compute a future fire time (via {@code getNextFireTimeInFuture}), use it.</li>
-   *   <li>If the trigger cannot compute a future time (e.g. it has ended), fall back to the stale
-   *       {@code nextFireTime}.</li>
-   *   <li>As a last resort, use the original {@code startTime}.</li>
-   * </ol>
-   *
-   * @param trigger the trigger whose timing is being normalized
-   * @return a {@link Date} to use as the start time for the rebuilt trigger
-   */
-  private Date determineNormalizedStartTime( Trigger trigger ) {
-    Date futureFireTime = getNextFireTimeInFuture( trigger );
-    if ( futureFireTime != null ) {
-      return futureFireTime;
-    }
-
-    Date nextFireTime = trigger.getNextFireTime();
-    if ( nextFireTime != null ) {
-      return nextFireTime;
-    }
-
-    return trigger.getStartTime();
   }
 
   /**

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -116,7 +117,7 @@ public class QuartzSchedulerSaveExecutionDateTest {
     Trigger mockTrigger = mock( Trigger.class );
 
     when( mockTrigger.getTriggerBuilder() ).thenAnswer( unused -> TriggerBuilder.newTrigger() );
-    when( mockTrigger.getNextFireTime() ).thenReturn( new Date() );
+    when( mockTrigger.getNextFireTime() ).thenReturn( new Date( System.currentTimeMillis() + 60_000 ) );
 
     when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
     when( mockScheduler.getTriggersOfJob( jobKey ) )
@@ -402,6 +403,64 @@ public class QuartzSchedulerSaveExecutionDateTest {
     assertNotNull( TRIGGER_EXISTS_MESSAGE, newTrigger );
     assertEquals( "New trigger should be PAUSED after saveExecutionDate", Trigger.TriggerState.PAUSED,
       scheduler.getTriggerState( newTrigger.getKey() ) );
+  }
+
+  /**
+   * Regression test for the run-once / end-dated rescheduling loop.
+   *
+   * When a trigger's {@code nextFireTime} is {@code null} (i.e. a run-once schedule or a job whose
+   * {@code endTime} has already lapsed), {@code saveExecutionDate} must NOT delete and reschedule
+   * the job. Before the fix, {@code determineNormalizedStartTime()} would fall back to the trigger's
+   * {@code startTime} (a date in the past). Rescheduling with that past start time combined with
+   * {@code MISFIRE_INSTRUCTION_FIRE_ONCE_NOW} caused an infinite execution loop: each execution
+   * called {@code saveExecutionDate}, which rescheduled with the same past start time, which fired
+   * immediately, and so on.
+   */
+  @Test
+  public void testSaveExecutionDateForExpiredTriggerSkipsNormalization() throws Exception {
+    // Arrange: a trigger whose lifecycle is complete — nextFireTime is null.
+    // This models a RUN_ONCE job after its single execution, or any job whose endTime has lapsed.
+    // startTime is set to the past so that the pre-fix fallback path (startTime) would produce
+    // an immediate misfire fire when the trigger were rescheduled.
+    Date executionTime = new Date();
+    JobDetail mockJobDetail = mock( JobDetail.class );
+    JobKey jobKey = new JobKey( TEST_JOB, TEST_GROUP );
+    JobDataMap jobDataMap = new JobDataMap();
+
+    when( mockJobDetail.getKey() ).thenReturn( jobKey );
+    when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
+    when( mockJobDetail.getJobClass() ).thenReturn( (Class) BlockingQuartzJob.class );
+
+    CalendarIntervalTriggerImpl expiredTrigger = new CalendarIntervalTriggerImpl();
+    expiredTrigger.setKey( new TriggerKey( TEST_TRIGGER, TEST_GROUP ) );
+    expiredTrigger.setJobKey( jobKey );
+    expiredTrigger.setRepeatInterval( 2 );
+    expiredTrigger.setRepeatIntervalUnit( DateBuilder.IntervalUnit.YEAR );
+    expiredTrigger.setStartTime( new Date( System.currentTimeMillis() - 60_000 ) );
+    expiredTrigger.setEndTime( new Date( System.currentTimeMillis() - 30_000 ) );
+    expiredTrigger.setMisfireInstruction( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_FIRE_ONCE_NOW );
+    // nextFireTime is null (default) — the scheduler has not computed any future fire time,
+    // which is the state after the last execution of a run-once or end-dated job.
+
+    Scheduler mockScheduler = mock( Scheduler.class );
+    when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
+    when( mockScheduler.getTriggersOfJob( jobKey ) )
+      .thenAnswer( unused -> Collections.singletonList( expiredTrigger ) );
+
+    SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
+    when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
+
+    QuartzScheduler mockQuartzScheduler = new QuartzScheduler();
+    mockQuartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
+
+    // Act
+    mockQuartzScheduler.saveExecutionDate( jobKey, executionTime );
+
+    // Assert: the job must NOT be deleted and rescheduled.
+    // Rescheduling with a past startTime + MISFIRE_INSTRUCTION_FIRE_ONCE_NOW
+    // would trigger an immediate execution and create an infinite loop.
+    verify( mockScheduler, never() ).deleteJob( jobKey );
+    verify( mockScheduler, never() ).scheduleJob( any( JobDetail.class ), any( Trigger.class ) );
   }
 
   @Test

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
@@ -421,7 +421,7 @@ public class QuartzSchedulerSaveExecutionDateTest {
     // Arrange: a trigger whose lifecycle is complete — nextFireTime is null.
     // This models a RUN_ONCE job after its single execution, or any job whose endTime has lapsed.
     // startTime is set to the past so that the pre-fix fallback path (startTime) would produce
-    // an immediate misfire fire when the trigger were rescheduled.
+    // an immediate misfire firing when the trigger was rescheduled.
     Date executionTime = new Date();
     JobDetail mockJobDetail = mock( JobDetail.class );
     JobKey jobKey = new JobKey( TEST_JOB, TEST_GROUP );


### PR DESCRIPTION
Fixes a critical bug where expired triggers (nextFireTime=null) were rescheduled with past startTime, causing infinite execution loop. Now skips normalization for expired triggers.
