### PR TITLE
feat[SP-7216]: receive an email when a schedule fails (#370)

### DIFF
--- a/core/src/main/java/org/pentaho/platform/scheduler2/action/ActionRunner.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/action/ActionRunner.java
@@ -102,10 +102,17 @@ public class ActionRunner implements IActionRunner {
       if ( result.isSuccess() ) {
         WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.SUCCEEDED );
       } else {
+        if ( !isRetry() ) {
+          ActionUtil.sendFailureEmail( params, null );
+        }
         WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.FAILED );
       }
       return result.updateRequired();
     } catch ( final Throwable t ) {
+      // Skip failure email on RunOnce retry jobs — the first run already sent it
+      if ( !isRetry() ) {
+        ActionUtil.sendFailureEmail( params, t );
+      }
       // ensure that the main thread isn't blocked on lock
       synchronized ( lock ) {
         lock.notifyAll();
@@ -116,6 +123,11 @@ public class ActionRunner implements IActionRunner {
       throw new ActionInvocationException( Messages.getInstance().getActionFailedToExecute( actionBean //$NON-NLS-1$
         .getClass().getName() ), t );
     }
+  }
+
+  private boolean isRetry() {
+    return Boolean.TRUE.equals( params.get( ActionUtil.QUARTZ_RESTART_FLAG ) )
+      || Boolean.TRUE.equals( params.get( ActionUtil.INVOKER_RESTART_FLAG ) );
   }
 
   private ExecutionResult callImpl() throws Exception {
@@ -203,7 +215,9 @@ public class ActionRunner implements IActionRunner {
           lock.wait( 1000 );
         }
       }
-      sendEmail( actionParams );
+      if ( executionStatus ) {
+        sendEmail( actionParams );
+      }
       deleteFileIfEmpty();
     }
     if ( actionBean instanceof IPostProcessingAction ) {

--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/ActionAdapterQuartzJob.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/ActionAdapterQuartzJob.java
@@ -148,6 +148,13 @@ public class ActionAdapterQuartzJob implements Job {
 
     final String workItemName = ActionUtil.extractName( params );
 
+    // Inject the schedule name into params so it is available for failure email subjects
+    try {
+      params.putIfAbsent( "jobName", QuartzJobKey.parse( context.getJobDetail().getKey().getName() ).getJobName() );
+    } catch ( final Exception ignored ) {
+      // If this fails it's OK since jobName is not strictly needed
+    }
+
     WorkItemLifecycleEventUtil.publish( workItemName, params, WorkItemLifecyclePhase.SUBMITTED );
 
     // creates an instance of IActionInvoker, which knows how to invoke this IAction - if the IActionInvoker bean is

--- a/core/src/test/java/org/pentaho/platform/scheduler2/action/ActionRunnerTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/action/ActionRunnerTest.java
@@ -13,6 +13,25 @@
 
 package org.pentaho.platform.scheduler2.action;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.pentaho.platform.scheduler2.action.ActionRunner.KEY_JCR_OUTPUT_PATH;
+import static org.pentaho.platform.scheduler2.action.ActionRunner.KEY_USE_JCR;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,27 +51,9 @@ import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.security.SecurityHelper;
 import org.pentaho.platform.engine.services.actions.TestVarArgsAction;
 import org.pentaho.platform.scheduler2.ISchedulerOutputPathResolver;
+import org.pentaho.platform.util.ActionUtil;
 import org.pentaho.platform.util.bean.TestAction;
 import org.pentaho.platform.util.messages.LocaleHelper;
-
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.pentaho.platform.scheduler2.action.ActionRunner.KEY_JCR_OUTPUT_PATH;
-import static org.pentaho.platform.scheduler2.action.ActionRunner.KEY_USE_JCR;
 
 @RunWith( MockitoJUnitRunner.class )
 public class ActionRunnerTest {
@@ -156,6 +157,80 @@ public class ActionRunnerTest {
     ActionRunner actionRunner = new ActionRunner( actionBeanSpy, "actionUser", paramsMap, mockStreamProvider );
     exception.expect( ActionInvocationException.class );
     actionRunner.call();
+  }
+
+  @Test
+  public void testFailureEmailSentWhenExecutionStatusFalse() throws Exception {
+    Map<String, Object> paramsMap = createMapWithUserLocale();
+    IAction actionBeanSpy = Mockito.spy( new TestAction() );
+    Mockito.doReturn( false ).when( actionBeanSpy ).isExecutionSuccessful();
+
+    ActionRunner actionRunner = new ActionRunner( actionBeanSpy, "actionUser", paramsMap, null );
+
+    try ( MockedStatic<ActionUtil> actionUtilStatic = Mockito.mockStatic( ActionUtil.class, Mockito.CALLS_REAL_METHODS ) ) {
+      actionRunner.call();
+
+      actionUtilStatic.verify( () -> ActionUtil.sendFailureEmail( paramsMap, null ), times( 1 ) );
+    }
+  }
+
+  @Test
+  public void testFailureEmailSentWhenExceptionThrown() throws Exception {
+    Map<String, Object> paramsMap = createMapWithUserLocale();
+    IAction actionBeanSpy = Mockito.spy( new TestAction() );
+    IBackgroundExecutionStreamProvider mockStreamProvider = Mockito.mock( IBackgroundExecutionStreamProvider.class );
+    Exception boom = new Exception( "something went wrong" );
+
+    try ( MockedStatic<ActionUtil> actionUtilStatic = Mockito.mockStatic( ActionUtil.class, Mockito.CALLS_REAL_METHODS ) ) {
+      when( mockStreamProvider.getInputStream() ).thenThrow( boom );
+
+      ActionRunner actionRunner = new ActionRunner( actionBeanSpy, "actionUser", paramsMap, mockStreamProvider );
+      exception.expect( ActionInvocationException.class );
+      try {
+        actionRunner.call();
+      } finally {
+        actionUtilStatic.verify( () -> ActionUtil.sendFailureEmail( paramsMap, boom ), times( 1 ) );
+      }
+    }
+  }
+
+  @Test
+  public void testFailureEmailNotSentWhenRestartFlagPresent() throws Exception {
+    Map<String, Object> paramsMap = createMapWithUserLocale();
+    paramsMap.put( ActionUtil.QUARTZ_RESTART_FLAG, Boolean.TRUE );
+
+    IAction actionBeanSpy = Mockito.spy( new TestAction() );
+    Mockito.doReturn( false ).when( actionBeanSpy ).isExecutionSuccessful();
+
+    ActionRunner actionRunner = new ActionRunner( actionBeanSpy, "actionUser", paramsMap, null );
+
+    try ( MockedStatic<ActionUtil> actionUtilStatic = Mockito.mockStatic( ActionUtil.class, Mockito.CALLS_REAL_METHODS ) ) {
+      actionRunner.call();
+
+      actionUtilStatic.verify( () -> ActionUtil.sendFailureEmail( paramsMap, null ), Mockito.never() );
+    }
+  }
+
+  @Test
+  public void testFailureEmailNotSentOnExceptionWhenRestartFlagPresent() throws Exception {
+    Map<String, Object> paramsMap = createMapWithUserLocale();
+    paramsMap.put( ActionUtil.QUARTZ_RESTART_FLAG, Boolean.TRUE );
+
+    IAction actionBeanSpy = Mockito.spy( new TestAction() );
+    IBackgroundExecutionStreamProvider mockStreamProvider = Mockito.mock( IBackgroundExecutionStreamProvider.class );
+    Exception boom = new Exception( "something went wrong" );
+
+    try ( MockedStatic<ActionUtil> actionUtilStatic = Mockito.mockStatic( ActionUtil.class, Mockito.CALLS_REAL_METHODS ) ) {
+      when( mockStreamProvider.getInputStream() ).thenThrow( boom );
+
+      ActionRunner actionRunner = new ActionRunner( actionBeanSpy, "actionUser", paramsMap, mockStreamProvider );
+      exception.expect( ActionInvocationException.class );
+      try {
+        actionRunner.call();
+      } finally {
+        actionUtilStatic.verify( () -> ActionUtil.sendFailureEmail( paramsMap, boom ), Mockito.never() );
+      }
+    }
   }
 
   private Map<String, Object> createMapWithUserLocale() {


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information

**SP Issue:** [SP-7216 - API's to determine the status of a report execution rather than the state of the schedule](https://hv-eng.atlassian.net/browse/SP-7216)
**Base Case:** [BISERVER-15398 - API's to determine the status of a report execution rather than the state of the schedule](https://hv-eng.atlassian.net/browse/BISERVER-15398)
**Original Master PR:** [pentaho/pentaho-scheduler-plugin#370](https://github.com/pentaho/pentaho-scheduler-plugin/pull/370)

## Changes
- Backported scheduler plugin changes required for schedule-failure email/status behavior
- Files: scheduler plugin source and related configuration updates
- Commit: 4cc44db

## Conflict Resolution
- No manual conflict resolution required in this repository
- Backport applied as a single policy-compliant commit with SP scope

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
- **Code Freeze Status:** Detected (SP2026 - 11.0.0.2), but backport only to maintenance branch per policy
