### PR TITLE
fix[SP-7209]: Backport BISERVER-15240/BISERVER-15614 Last Run and Scheduler stability fixes

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -137,6 +137,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-tx</artifactId>
     </dependency>

--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -643,6 +643,12 @@ public class QuartzScheduler implements IScheduler {
 
       JobDetail newJobDetail = recreateJobDetail( oldJobDetail, jobKey, jobDataMap );
       Trigger newTrigger = recreateTriggerWithNewStartTime( oldTrigger );
+      if ( newTrigger == null ) {
+        // The trigger has no future fire time (e.g. run-once or end-dated schedule whose lifecycle
+        // is complete). Rescheduling with a past startTime would cause an immediate misfire execution
+        // and an infinite loop, so normalization is skipped.
+        return;
+      }
 
       Scheduler scheduler = getQuartzScheduler();
       Trigger.TriggerState oldTriggerState = scheduler.getTriggerState( oldTrigger.getKey() );
@@ -684,15 +690,24 @@ public class QuartzScheduler implements IScheduler {
   }
 
   /**
-   * Recreates a trigger with the same properties as the old one, but with the new start time
+   * Recreates a trigger with the same properties as the old one, but with a normalized start time
    * to avoid duplicated executions due to misfire instructions.
    *
+   * <p>Returns {@code null} when the trigger has no future fire time — for example, a run-once
+   * schedule or a job whose {@code endTime} has already lapsed. In that case the caller must
+   * <em>not</em> reschedule the trigger; doing so with a past {@code startTime} combined with
+   * {@code MISFIRE_INSTRUCTION_FIRE_ONCE_NOW} would produce an immediate execution and an
+   * infinite rescheduling loop.</p>
+   *
    * @param oldTrigger the trigger to recreate
-   * @return a new trigger with updated start time, preserving original properties
+   * @return a new trigger with an updated start time preserving original properties,
+   *         or {@code null} if the trigger has no future fire times
    */
   private Trigger recreateTriggerWithNewStartTime( Trigger oldTrigger ) {
-    Trigger newTrigger;
-    Date normalizedStartTime = determineNormalizedStartTime( oldTrigger );
+    Date normalizedStartTime = getNextFireTimeInFuture( oldTrigger );
+    if ( normalizedStartTime == null ) {
+      return null;
+    }
 
     if ( oldTrigger instanceof CalendarIntervalTrigger calIntOldTrig ) {
       CalendarIntervalScheduleBuilder scheduleBuilder = CalendarIntervalScheduleBuilder.calendarIntervalSchedule()
@@ -703,47 +718,15 @@ public class QuartzScheduler implements IScheduler {
 
       scheduleBuilder = applyMisfireInstruction( scheduleBuilder, calIntOldTrig.getMisfireInstruction() );
 
-      newTrigger = calIntOldTrig.getTriggerBuilder()
+      return calIntOldTrig.getTriggerBuilder()
         .withSchedule( scheduleBuilder )
         .startAt( normalizedStartTime )
         .build();
     } else {
-      newTrigger = oldTrigger.getTriggerBuilder()
+      return oldTrigger.getTriggerBuilder()
         .startAt( normalizedStartTime )
         .build();
     }
-
-    return newTrigger;
-  }
-
-  /**
-   * Computes a start time for a rebuilt trigger that is guaranteed to be in the future whenever possible.
-   * This prevents Quartz's misfire logic from treating the rescheduled trigger as overdue and firing it
-   * immediately.
-   *
-   * <p>Resolution order:</p>
-   * <ol>
-   *   <li>If the trigger can compute a future fire time (via {@code getNextFireTimeInFuture}), use it.</li>
-   *   <li>If the trigger cannot compute a future time (e.g. it has ended), fall back to the stale
-   *       {@code nextFireTime}.</li>
-   *   <li>As a last resort, use the original {@code startTime}.</li>
-   * </ol>
-   *
-   * @param trigger the trigger whose timing is being normalized
-   * @return a {@link Date} to use as the start time for the rebuilt trigger
-   */
-  private Date determineNormalizedStartTime( Trigger trigger ) {
-    Date futureFireTime = getNextFireTimeInFuture( trigger );
-    if ( futureFireTime != null ) {
-      return futureFireTime;
-    }
-
-    Date nextFireTime = trigger.getNextFireTime();
-    if ( nextFireTime != null ) {
-      return nextFireTime;
-    }
-
-    return trigger.getStartTime();
   }
 
   /**

--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -595,35 +595,60 @@ public class QuartzScheduler implements IScheduler {
    * @throws org.quartz.SchedulerException if there is an error accessing the scheduler
    */
   protected void saveExecutionDate( JobKey jobKey, Date executionTime ) throws org.quartz.SchedulerException {
+    normalizeTriggerTimingState( jobKey, executionTime );
+  }
+
+  /**
+   * Rebuilds a job's trigger with a normalized start time and optionally updates the last execution timestamp
+   * in the job data map. This is necessary because Quartz's {@code CalendarIntervalTrigger} uses
+   * {@code MISFIRE_INSTRUCTION_FIRE_ONCE_NOW} by default, which causes the trigger to fire immediately
+   * whenever Quartz detects that {@code nextFireTime} is in the past. That happens after a paused schedule
+   * is resumed, or after the scheduler persists job data via delete-and-reschedule. Without rebuilding the
+   * trigger with a future start time, these operations would produce an unintended immediate execution.
+   *
+   * <p>The method deletes the existing job and reschedules it with a rebuilt {@link JobDetail} (carrying the
+   * potentially updated job data map) and a rebuilt trigger whose start time has been advanced to the next
+   * future fire time. The original trigger state (e.g. PAUSED) is restored after rescheduling.</p>
+   *
+   * @param jobKey the key identifying the job to normalize
+   * @param executionTime if non-null, the actual execution timestamp to store as the Last Run value;
+   *                      if null, the job data map is carried over without modification
+   * @throws org.quartz.SchedulerException if there is an error accessing the scheduler
+   */
+  private void normalizeTriggerTimingState( JobKey jobKey, Date executionTime ) throws org.quartz.SchedulerException {
     jobDetailLock.writeLock().lock();
     try {
       JobDetail oldJobDetail = getJobDetail( jobKey );
-
-      JobDataMap jobDataMap = oldJobDetail.getJobDataMap();
-      Object oldValue = jobDataMap.get( RESERVEDMAPKEY_LAST_EXECUTION_TIME );
-
-      // If the new execution time is before the currently stored execution time,
-      // do not update to ensure Last Run reflects the most recent execution
-      if ( oldValue instanceof Date && executionTime.before( (Date) oldValue ) ) {
+      if ( oldJobDetail == null ) {
         return;
       }
 
-      jobDataMap.put( RESERVEDMAPKEY_LAST_EXECUTION_TIME, executionTime );
-
-      JobDetail newJobDetail = JobBuilder.newJob( oldJobDetail.getJobClass() )
-        .withIdentity( jobKey )
-        .usingJobData( jobDataMap )
-        .build();
-
       Trigger oldTrigger = getSingleJobTrigger( jobKey );
+      if ( oldTrigger == null ) {
+        return;
+      }
+
+      JobDataMap jobDataMap = new JobDataMap( oldJobDetail.getJobDataMap() );
+      if ( executionTime != null ) {
+        Object oldValue = jobDataMap.get( RESERVEDMAPKEY_LAST_EXECUTION_TIME );
+
+        // If the new execution time is before the currently stored execution time,
+        // do not update to ensure Last Run reflects the most recent execution
+        if ( oldValue instanceof Date && executionTime.before( (Date) oldValue ) ) {
+          return;
+        }
+
+        jobDataMap.put( RESERVEDMAPKEY_LAST_EXECUTION_TIME, executionTime );
+      }
+
+      JobDetail newJobDetail = recreateJobDetail( oldJobDetail, jobKey, jobDataMap );
       Trigger newTrigger = recreateTriggerWithNewStartTime( oldTrigger );
 
-      // Capture the old trigger's state before deleting to preserve it on the new trigger
       Scheduler scheduler = getQuartzScheduler();
       Trigger.TriggerState oldTriggerState = scheduler.getTriggerState( oldTrigger.getKey() );
 
-      // Delete the old trigger and schedule the new one
-      // We cannot use addJob (update) since the JobDetail is not being stored durably, so it's immutable
+      // Delete and reschedule the job to persist both the updated trigger timing state
+      // and any optional job data changes while preserving the original trigger state.
       scheduler.deleteJob( jobKey );
       scheduler.scheduleJob( newJobDetail, newTrigger );
 
@@ -631,6 +656,31 @@ public class QuartzScheduler implements IScheduler {
     } finally {
       jobDetailLock.writeLock().unlock();
     }
+  }
+
+  /**
+   * Rebuilds a {@link JobDetail} preserving the original job class, identity, durability, recovery settings,
+   * and description, but with a new {@link JobDataMap}. This is needed because Quartz does not allow
+   * in-place mutation of a scheduled job's data map; the job must be deleted and rescheduled with a new
+   * {@link JobDetail} instance to persist changes such as the last execution timestamp.
+   *
+   * @param oldJobDetail the original job detail to copy settings from
+   * @param jobKey the job identity key
+   * @param jobDataMap the (potentially updated) job data map to attach to the new detail
+   * @return a new {@link JobDetail} with the same configuration but the provided data map
+   */
+  private JobDetail recreateJobDetail( JobDetail oldJobDetail, JobKey jobKey, JobDataMap jobDataMap ) {
+    JobBuilder jobBuilder = JobBuilder.newJob( oldJobDetail.getJobClass() )
+      .withIdentity( jobKey )
+      .usingJobData( jobDataMap )
+      .storeDurably( oldJobDetail.isDurable() )
+      .requestRecovery( oldJobDetail.requestsRecovery() );
+
+    if ( oldJobDetail.getDescription() != null ) {
+      jobBuilder.withDescription( oldJobDetail.getDescription() );
+    }
+
+    return jobBuilder.build();
   }
 
   /**
@@ -642,6 +692,7 @@ public class QuartzScheduler implements IScheduler {
    */
   private Trigger recreateTriggerWithNewStartTime( Trigger oldTrigger ) {
     Trigger newTrigger;
+    Date normalizedStartTime = determineNormalizedStartTime( oldTrigger );
 
     if ( oldTrigger instanceof CalendarIntervalTrigger calIntOldTrig ) {
       CalendarIntervalScheduleBuilder scheduleBuilder = CalendarIntervalScheduleBuilder.calendarIntervalSchedule()
@@ -654,15 +705,65 @@ public class QuartzScheduler implements IScheduler {
 
       newTrigger = calIntOldTrig.getTriggerBuilder()
         .withSchedule( scheduleBuilder )
-        .startAt( calIntOldTrig.getNextFireTime() )
+        .startAt( normalizedStartTime )
         .build();
     } else {
       newTrigger = oldTrigger.getTriggerBuilder()
-        .startAt( oldTrigger.getNextFireTime() )
+        .startAt( normalizedStartTime )
         .build();
     }
 
     return newTrigger;
+  }
+
+  /**
+   * Computes a start time for a rebuilt trigger that is guaranteed to be in the future whenever possible.
+   * This prevents Quartz's misfire logic from treating the rescheduled trigger as overdue and firing it
+   * immediately.
+   *
+   * <p>Resolution order:</p>
+   * <ol>
+   *   <li>If the trigger can compute a future fire time (via {@code getNextFireTimeInFuture}), use it.</li>
+   *   <li>If the trigger cannot compute a future time (e.g. it has ended), fall back to the stale
+   *       {@code nextFireTime}.</li>
+   *   <li>As a last resort, use the original {@code startTime}.</li>
+   * </ol>
+   *
+   * @param trigger the trigger whose timing is being normalized
+   * @return a {@link Date} to use as the start time for the rebuilt trigger
+   */
+  private Date determineNormalizedStartTime( Trigger trigger ) {
+    Date futureFireTime = getNextFireTimeInFuture( trigger );
+    if ( futureFireTime != null ) {
+      return futureFireTime;
+    }
+
+    Date nextFireTime = trigger.getNextFireTime();
+    if ( nextFireTime != null ) {
+      return nextFireTime;
+    }
+
+    return trigger.getStartTime();
+  }
+
+  /**
+   * Returns the next fire time in the future for a trigger, or null if no future fire time exists.
+   * If the current {@code nextFireTime} is already in the future, returns it directly; otherwise,
+   * computes the next fire time after <em>now</em> using the trigger's interval/schedule.
+   *
+   * @param trigger the trigger to compute the next fire time for
+   * @return a future fire time, or null if the trigger cannot compute a future time
+   */
+  private Date getNextFireTimeInFuture( Trigger trigger ) {
+    Date nextFireTime = trigger.getNextFireTime();
+    if ( nextFireTime == null ) {
+      return null;
+    }
+
+    Date now = new Date();
+    return nextFireTime.after( now )
+      ? nextFireTime
+      : trigger.getFireTimeAfter( now );
   }
 
   /**
@@ -844,12 +945,7 @@ public class QuartzScheduler implements IScheduler {
   }
 
   protected void setJobNextRun( Job job, Trigger trigger ) {
-    //if getNextFireTime() is in the future, then we use it
-    //if it is in the past, we call getFireTimeAfter( new Date() ) to get the correct next date from today on
-    Date nextFire = trigger.getNextFireTime();
-    job.setNextRun( nextFire != null && ( nextFire.getTime() < new Date().getTime() )
-      ? trigger.getFireTimeAfter( new Date() )
-      : nextFire );
+    job.setNextRun( getNextFireTimeInFuture( trigger ) );
   }
 
   private void setJobTrigger( Scheduler scheduler, Job job, Trigger trigger ) throws SchedulerException,
@@ -1075,7 +1171,9 @@ public class QuartzScheduler implements IScheduler {
   public void resumeJob( String jobId ) throws SchedulerException {
     try {
       Scheduler scheduler = getQuartzScheduler();
-      scheduler.resumeJob( new JobKey( jobId, QuartzJobKey.parse( jobId ).getUserName() ) );
+      JobKey jobKey = new JobKey( jobId, QuartzJobKey.parse( jobId ).getUserName() );
+      normalizeTriggerTimingState( jobKey, null );
+      scheduler.resumeJob( jobKey );
     } catch ( org.quartz.SchedulerException e ) {
       throw new SchedulerException( Messages.getString(
         QUARTZ_SCHEDULER_ERROR_0005_FAILED_TO_RESUME_JOBS ), e );

--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -594,14 +594,14 @@ public class QuartzScheduler implements IScheduler {
    * @param executionTime the time the job was executed
    * @throws org.quartz.SchedulerException if there is an error accessing the scheduler
    */
-  protected void saveExecutionDate( JobKey jobKey, Date executionTime ) throws org.quartz.SchedulerException {    
+  protected void saveExecutionDate( JobKey jobKey, Date executionTime ) throws org.quartz.SchedulerException {
     jobDetailLock.writeLock().lock();
     try {
       JobDetail oldJobDetail = getJobDetail( jobKey );
 
       JobDataMap jobDataMap = oldJobDetail.getJobDataMap();
       Object oldValue = jobDataMap.get( RESERVEDMAPKEY_LAST_EXECUTION_TIME );
-    
+
       // If the new execution time is before the currently stored execution time,
       // do not update to ensure Last Run reflects the most recent execution
       if ( oldValue instanceof Date && executionTime.before( (Date) oldValue ) ) {
@@ -609,51 +609,102 @@ public class QuartzScheduler implements IScheduler {
       }
 
       jobDataMap.put( RESERVEDMAPKEY_LAST_EXECUTION_TIME, executionTime );
-    
+
       JobDetail newJobDetail = JobBuilder.newJob( oldJobDetail.getJobClass() )
         .withIdentity( jobKey )
         .usingJobData( jobDataMap )
         .build();
 
       Trigger oldTrigger = getSingleJobTrigger( jobKey );
+      Trigger newTrigger = recreateTriggerWithNewStartTime( oldTrigger );
 
-      // Create a new trigger with the same properties as the old one, but with the new start time
-      // to avoid duplicated executions due to misfire instructions
-      Trigger newTrigger = null;
-      if ( oldTrigger instanceof CalendarIntervalTrigger calIntOldTrig ) {
-        CalendarIntervalScheduleBuilder scheduleBuilder = CalendarIntervalScheduleBuilder.calendarIntervalSchedule()
-          .withInterval( calIntOldTrig.getRepeatInterval(), calIntOldTrig.getRepeatIntervalUnit() )
-          .inTimeZone( calIntOldTrig.getTimeZone() )
-          .preserveHourOfDayAcrossDaylightSavings(
-            calIntOldTrig.isPreserveHourOfDayAcrossDaylightSavings() )
-          .skipDayIfHourDoesNotExist( calIntOldTrig.isSkipDayIfHourDoesNotExist() );
-        int misfireInstruction = calIntOldTrig.getMisfireInstruction();
-        if ( misfireInstruction == CalendarIntervalTrigger.MISFIRE_INSTRUCTION_DO_NOTHING ) {
-          scheduleBuilder = scheduleBuilder.withMisfireHandlingInstructionDoNothing();
-        } else if ( misfireInstruction == CalendarIntervalTrigger.MISFIRE_INSTRUCTION_FIRE_ONCE_NOW ) {
-          scheduleBuilder = scheduleBuilder.withMisfireHandlingInstructionFireAndProceed();
-        }
-        newTrigger = calIntOldTrig.getTriggerBuilder()
-          .withSchedule( scheduleBuilder )
-          .startAt( calIntOldTrig.getNextFireTime() )
-          .build();
-      } else {
-        newTrigger = oldTrigger.getTriggerBuilder()
-          .startAt( oldTrigger.getNextFireTime() )
-          .build();
-      }
+      // Capture the old trigger's state before deleting to preserve it on the new trigger
+      Scheduler scheduler = getQuartzScheduler();
+      Trigger.TriggerState oldTriggerState = scheduler.getTriggerState( oldTrigger.getKey() );
 
       // Delete the old trigger and schedule the new one
       // We cannot use addJob (update) since the JobDetail is not being stored durably, so it's immutable
-      getQuartzScheduler().deleteJob( jobKey );
-      getQuartzScheduler().scheduleJob( newJobDetail, newTrigger );
+      scheduler.deleteJob( jobKey );
+      scheduler.scheduleJob( newJobDetail, newTrigger );
+
+      restoreTriggerState( scheduler, oldTriggerState, newTrigger );
     } finally {
       jobDetailLock.writeLock().unlock();
     }
   }
 
   /**
+   * Recreates a trigger with the same properties as the old one, but with the new start time
+   * to avoid duplicated executions due to misfire instructions.
+   *
+   * @param oldTrigger the trigger to recreate
+   * @return a new trigger with updated start time, preserving original properties
+   */
+  private Trigger recreateTriggerWithNewStartTime( Trigger oldTrigger ) {
+    Trigger newTrigger;
+
+    if ( oldTrigger instanceof CalendarIntervalTrigger calIntOldTrig ) {
+      CalendarIntervalScheduleBuilder scheduleBuilder = CalendarIntervalScheduleBuilder.calendarIntervalSchedule()
+        .withInterval( calIntOldTrig.getRepeatInterval(), calIntOldTrig.getRepeatIntervalUnit() )
+        .inTimeZone( calIntOldTrig.getTimeZone() )
+        .preserveHourOfDayAcrossDaylightSavings( calIntOldTrig.isPreserveHourOfDayAcrossDaylightSavings() )
+        .skipDayIfHourDoesNotExist( calIntOldTrig.isSkipDayIfHourDoesNotExist() );
+
+      scheduleBuilder = applyMisfireInstruction( scheduleBuilder, calIntOldTrig.getMisfireInstruction() );
+
+      newTrigger = calIntOldTrig.getTriggerBuilder()
+        .withSchedule( scheduleBuilder )
+        .startAt( calIntOldTrig.getNextFireTime() )
+        .build();
+    } else {
+      newTrigger = oldTrigger.getTriggerBuilder()
+        .startAt( oldTrigger.getNextFireTime() )
+        .build();
+    }
+
+    return newTrigger;
+  }
+
+  /**
+   * Applies the appropriate misfire handling instruction to the schedule builder.
+   *
+   * @param scheduleBuilder the schedule builder to configure
+   * @param misfireInstruction the misfire instruction from the old trigger
+   * @return the configured schedule builder
+   */
+  private CalendarIntervalScheduleBuilder applyMisfireInstruction(
+    CalendarIntervalScheduleBuilder scheduleBuilder, int misfireInstruction ) {
+    switch ( misfireInstruction ) {
+      case Trigger.MISFIRE_INSTRUCTION_IGNORE_MISFIRE_POLICY:
+        return scheduleBuilder.withMisfireHandlingInstructionIgnoreMisfires();
+      case CalendarIntervalTrigger.MISFIRE_INSTRUCTION_DO_NOTHING:
+        return scheduleBuilder.withMisfireHandlingInstructionDoNothing();
+      case CalendarIntervalTrigger.MISFIRE_INSTRUCTION_FIRE_ONCE_NOW:
+        return scheduleBuilder.withMisfireHandlingInstructionFireAndProceed();
+      default:
+        return scheduleBuilder;
+    }
+  }
+
+  /**
+   * Restores the trigger's previous state after it has been recreated and scheduled.
+   * If the old trigger was in PAUSED state, the new trigger will be paused as well.
+   *
+   * @param scheduler the Quartz scheduler instance
+   * @param oldTriggerState the original state of the trigger before deletion
+   * @param newTrigger the newly created trigger that may need to be paused
+   * @throws org.quartz.SchedulerException if there is an error pausing the trigger
+   */
+  private void restoreTriggerState( Scheduler scheduler, Trigger.TriggerState oldTriggerState,
+    Trigger newTrigger ) throws org.quartz.SchedulerException {
+    if ( oldTriggerState == Trigger.TriggerState.PAUSED ) {
+      scheduler.pauseTrigger( newTrigger.getKey() );
+    }
+  }
+
+  /**
    * Indicates if this trigger was created by quartz internally as a result of a triggerJob call
+   *
    * @param trigger the trigger to check
    * @return true if the trigger is a manual trigger, false otherwise
    */

--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -362,7 +362,6 @@ public class QuartzScheduler implements IScheduler {
       calendarIntervalTrigger.setEndTime( triggerEndDate );
     }
 
-  
     calendarIntervalTrigger.setStartTime( startDateCal.getTime() );
     if ( tz != null ) {
       calendarIntervalTrigger.setTimeZone( tz );

--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -60,6 +60,7 @@ import org.pentaho.platform.web.http.api.resources.JobScheduleParam;
 import org.pentaho.platform.web.http.api.resources.JobScheduleRequest;
 import org.pentaho.platform.web.http.api.resources.SchedulerResource;
 import org.quartz.Calendar;
+import org.quartz.CalendarIntervalScheduleBuilder;
 import org.quartz.CalendarIntervalTrigger;
 import org.quartz.CronExpression;
 import org.quartz.CronScheduleBuilder;
@@ -600,9 +601,29 @@ public class QuartzScheduler implements IScheduler {
 
       // Create a new trigger with the same properties as the old one, but with the new start time
       // to avoid duplicated executions due to misfire instructions
-      Trigger newTrigger = oldTrigger.getTriggerBuilder()
-        .startAt( oldTrigger.getNextFireTime() )
-        .build();
+      Trigger newTrigger = null;
+      if ( oldTrigger instanceof CalendarIntervalTrigger calIntOldTrig ) {
+        CalendarIntervalScheduleBuilder scheduleBuilder = CalendarIntervalScheduleBuilder.calendarIntervalSchedule()
+          .withInterval( calIntOldTrig.getRepeatInterval(), calIntOldTrig.getRepeatIntervalUnit() )
+          .inTimeZone( calIntOldTrig.getTimeZone() )
+          .preserveHourOfDayAcrossDaylightSavings(
+            calIntOldTrig.isPreserveHourOfDayAcrossDaylightSavings() )
+          .skipDayIfHourDoesNotExist( calIntOldTrig.isSkipDayIfHourDoesNotExist() );
+        int misfireInstruction = calIntOldTrig.getMisfireInstruction();
+        if ( misfireInstruction == CalendarIntervalTrigger.MISFIRE_INSTRUCTION_DO_NOTHING ) {
+          scheduleBuilder = scheduleBuilder.withMisfireHandlingInstructionDoNothing();
+        } else if ( misfireInstruction == CalendarIntervalTrigger.MISFIRE_INSTRUCTION_FIRE_ONCE_NOW ) {
+          scheduleBuilder = scheduleBuilder.withMisfireHandlingInstructionFireAndProceed();
+        }
+        newTrigger = calIntOldTrig.getTriggerBuilder()
+          .withSchedule( scheduleBuilder )
+          .startAt( calIntOldTrig.getNextFireTime() )
+          .build();
+      } else {
+        newTrigger = oldTrigger.getTriggerBuilder()
+          .startAt( oldTrigger.getNextFireTime() )
+          .build();
+      }
 
       // Delete the old trigger and schedule the new one
       // We cannot use addJob since the JobDetail is not being stored durably, so it's immutable

--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/QuartzScheduler.java
@@ -574,9 +574,6 @@ public class QuartzScheduler implements IScheduler {
     try {
       QuartzJobKey quartzJobKey = QuartzJobKey.parse( jobId );
       JobKey jobKey = new JobKey( jobId, quartzJobKey.getUserName() );
-
-      saveTriggerNowDate( jobKey, new Date() );
-
       getQuartzScheduler().triggerJob( jobKey );
     } catch ( org.quartz.SchedulerException e ) {
       throw new SchedulerException( Messages.getInstance().getString(
@@ -584,13 +581,34 @@ public class QuartzScheduler implements IScheduler {
     }
   }
 
-  private void saveTriggerNowDate( JobKey jobKey, Date newDate ) throws org.quartz.SchedulerException {
+  /**
+   * Saves the actual execution timestamp when a job successfully executes.
+   * This timestamp is used for the Last Run field and only updates when the job actually runs,
+   * not when it's blocked by blockout periods.
+   *
+   * This method is thread-safe and prevents race conditions where multiple concurrent executions
+   * might try to update the timestamp. If a newer execution timestamp already exists, older
+   * timestamps are ignored to ensure Last Run always reflects the most recent actual execution.
+   *
+   * @param jobKey the key of the executed job
+   * @param executionTime the time the job was executed
+   * @throws org.quartz.SchedulerException if there is an error accessing the scheduler
+   */
+  protected void saveExecutionDate( JobKey jobKey, Date executionTime ) throws org.quartz.SchedulerException {    
     jobDetailLock.writeLock().lock();
     try {
       JobDetail oldJobDetail = getJobDetail( jobKey );
 
       JobDataMap jobDataMap = oldJobDetail.getJobDataMap();
-      jobDataMap.put( RESERVEDMAPKEY_PREVIOUS_TRIGGER_NOW, newDate );
+      Object oldValue = jobDataMap.get( RESERVEDMAPKEY_LAST_EXECUTION_TIME );
+    
+      // If the new execution time is before the currently stored execution time,
+      // do not update to ensure Last Run reflects the most recent execution
+      if ( oldValue instanceof Date && executionTime.before( (Date) oldValue ) ) {
+        return;
+      }
+
+      jobDataMap.put( RESERVEDMAPKEY_LAST_EXECUTION_TIME, executionTime );
     
       JobDetail newJobDetail = JobBuilder.newJob( oldJobDetail.getJobClass() )
         .withIdentity( jobKey )
@@ -626,7 +644,7 @@ public class QuartzScheduler implements IScheduler {
       }
 
       // Delete the old trigger and schedule the new one
-      // We cannot use addJob since the JobDetail is not being stored durably, so it's immutable
+      // We cannot use addJob (update) since the JobDetail is not being stored durably, so it's immutable
       getQuartzScheduler().deleteJob( jobKey );
       getQuartzScheduler().scheduleJob( newJobDetail, newTrigger );
     } finally {
@@ -742,19 +760,15 @@ public class QuartzScheduler implements IScheduler {
     return jobs;
   }
 
+  /** 
+   * Gets the last run time for a job based on the actual execution timestamp. This method checks
+   * the custom execution time stored in the job data map, which is only updated when the job
+   * actually executes, ensuring accurate Last Run values even during blockout periods.
+   * 
+   * @param trigger the job trigger
+   * @return the last run time of the job, or null if the job has never executed
+   */
   protected Date getLastRun( Trigger trigger ) {
-    Date previousTriggerNow = getPreviousTriggerNow( trigger );
-    Date previousFireTime = trigger.getPreviousFireTime();
-
-    if ( previousTriggerNow == null ) {
-      return previousFireTime;
-    }
-
-    return ( previousFireTime == null || previousTriggerNow.after( previousFireTime ) )
-         ? previousTriggerNow : previousFireTime;
-  }
-
-  private Date getPreviousTriggerNow( Trigger trigger ) {
     JobDetail jobDetail;
 
     try {
@@ -765,16 +779,17 @@ public class QuartzScheduler implements IScheduler {
     }
 
     JobDataMap jobDataMap = jobDetail.getJobDataMap();
-    if ( !jobDetail.getJobDataMap().containsKey( RESERVEDMAPKEY_PREVIOUS_TRIGGER_NOW ) ) {
+    boolean hasKey = jobDetail.getJobDataMap().containsKey( RESERVEDMAPKEY_LAST_EXECUTION_TIME );
+    if ( !hasKey ) {
       return null;
     }
 
-    Object previousTriggerNowObj = jobDataMap.get( RESERVEDMAPKEY_PREVIOUS_TRIGGER_NOW );
-    if ( !( previousTriggerNowObj instanceof Date ) ) {
+    Object lastExecutionTimeObj = jobDataMap.get( RESERVEDMAPKEY_LAST_EXECUTION_TIME );
+    if ( !( lastExecutionTimeObj instanceof Date ) ) {
       return null;
     }
 
-    return (Date) previousTriggerNowObj;
+    return (Date) lastExecutionTimeObj;
   }
 
   protected void setJobNextRun( Job job, Trigger trigger ) {

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -116,7 +117,7 @@ public class QuartzSchedulerSaveExecutionDateTest {
     Trigger mockTrigger = mock( Trigger.class );
 
     when( mockTrigger.getTriggerBuilder() ).thenAnswer( unused -> TriggerBuilder.newTrigger() );
-    when( mockTrigger.getNextFireTime() ).thenReturn( new Date() );
+    when( mockTrigger.getNextFireTime() ).thenReturn( new Date( System.currentTimeMillis() + 60_000 ) );
 
     when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
     when( mockScheduler.getTriggersOfJob( jobKey ) )
@@ -402,6 +403,64 @@ public class QuartzSchedulerSaveExecutionDateTest {
     assertNotNull( TRIGGER_EXISTS_MESSAGE, newTrigger );
     assertEquals( "New trigger should be PAUSED after saveExecutionDate", Trigger.TriggerState.PAUSED,
       scheduler.getTriggerState( newTrigger.getKey() ) );
+  }
+
+  /**
+   * Regression test for the run-once / end-dated rescheduling loop.
+   *
+   * When a trigger's {@code nextFireTime} is {@code null} (i.e. a run-once schedule or a job whose
+   * {@code endTime} has already lapsed), {@code saveExecutionDate} must NOT delete and reschedule
+   * the job. Before the fix, {@code determineNormalizedStartTime()} would fall back to the trigger's
+   * {@code startTime} (a date in the past). Rescheduling with that past start time combined with
+   * {@code MISFIRE_INSTRUCTION_FIRE_ONCE_NOW} caused an infinite execution loop: each execution
+   * called {@code saveExecutionDate}, which rescheduled with the same past start time, which fired
+   * immediately, and so on.
+   */
+  @Test
+  public void testSaveExecutionDateForExpiredTriggerSkipsNormalization() throws Exception {
+    // Arrange: a trigger whose lifecycle is complete — nextFireTime is null.
+    // This models a RUN_ONCE job after its single execution, or any job whose endTime has lapsed.
+    // startTime is set to the past so that the pre-fix fallback path (startTime) would produce
+    // an immediate misfire firing when the trigger was rescheduled.
+    Date executionTime = new Date();
+    JobDetail mockJobDetail = mock( JobDetail.class );
+    JobKey jobKey = new JobKey( TEST_JOB, TEST_GROUP );
+    JobDataMap jobDataMap = new JobDataMap();
+
+    when( mockJobDetail.getKey() ).thenReturn( jobKey );
+    when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
+    when( mockJobDetail.getJobClass() ).thenReturn( (Class) BlockingQuartzJob.class );
+
+    CalendarIntervalTriggerImpl expiredTrigger = new CalendarIntervalTriggerImpl();
+    expiredTrigger.setKey( new TriggerKey( TEST_TRIGGER, TEST_GROUP ) );
+    expiredTrigger.setJobKey( jobKey );
+    expiredTrigger.setRepeatInterval( 2 );
+    expiredTrigger.setRepeatIntervalUnit( DateBuilder.IntervalUnit.YEAR );
+    expiredTrigger.setStartTime( new Date( System.currentTimeMillis() - 60_000 ) );
+    expiredTrigger.setEndTime( new Date( System.currentTimeMillis() - 30_000 ) );
+    expiredTrigger.setMisfireInstruction( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_FIRE_ONCE_NOW );
+    // nextFireTime is null (default) — the scheduler has not computed any future fire time,
+    // which is the state after the last execution of a run-once or end-dated job.
+
+    Scheduler mockScheduler = mock( Scheduler.class );
+    when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
+    when( mockScheduler.getTriggersOfJob( jobKey ) )
+      .thenAnswer( unused -> Collections.singletonList( expiredTrigger ) );
+
+    SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
+    when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
+
+    QuartzScheduler mockQuartzScheduler = new QuartzScheduler();
+    mockQuartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
+
+    // Act
+    mockQuartzScheduler.saveExecutionDate( jobKey, executionTime );
+
+    // Assert: the job must NOT be deleted and rescheduled.
+    // Rescheduling with a past startTime + MISFIRE_INSTRUCTION_FIRE_ONCE_NOW
+    // would trigger an immediate execution and create an infinite loop.
+    verify( mockScheduler, never() ).deleteJob( jobKey );
+    verify( mockScheduler, never() ).scheduleJob( any( JobDetail.class ), any( Trigger.class ) );
   }
 
   @Test

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
@@ -1,0 +1,369 @@
+package org.pentaho.platform.scheduler2.quartz;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.quartz.CalendarIntervalScheduleBuilder;
+import org.quartz.CalendarIntervalTrigger;
+import org.quartz.DateBuilder;
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerFactory;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
+import org.quartz.impl.StdSchedulerFactory;
+import org.quartz.impl.triggers.CalendarIntervalTriggerImpl;
+import org.quartz.impl.triggers.CronTriggerImpl;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class QuartzSchedulerSaveExecutionDateTest {
+
+  private static final String TRIGGER_EXISTS_MESSAGE = "A trigger should exist after saveExecutionDate";
+  private static final String TEST_GROUP = "testGroup";
+  private static final String TEST_VALUE = "value1";
+  private static final String TEST_JOB = "testJob";
+  private static final String TEST_TRIGGER = "testTrigger";
+  private static final String MOCK_TEST_GROUP = "test-group";
+  private static final String PARAM_KEY = "key1";
+  private static final String UTC_TIMEZONE = "UTC";
+  private static final String MANUAL_TRIGGER_PREFIX = "MT_";
+  private static final String MOCK_CALENDAR_NAME = "my-calendar";
+  private static final String CRON_CALENDAR_NAME = "cron-calendar";
+
+  private Scheduler scheduler;
+  private QuartzScheduler quartzScheduler;
+
+  @Before
+  public void setUp() throws Exception {
+    scheduler = new StdSchedulerFactory().getScheduler();
+    scheduler.start();
+    quartzScheduler = new QuartzScheduler();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if ( scheduler != null && scheduler.isStarted() ) {
+      scheduler.shutdown();
+    }
+  }
+
+  @Test
+  public void testSaveExecutionDate() throws Exception {
+    // Arrange
+    Date executionTime = new Date();
+    JobDetail mockJobDetail = mock( JobDetail.class );
+    JobKey jobKey = new JobKey( TEST_JOB, TEST_GROUP );
+    JobDataMap jobDataMap = new JobDataMap();
+
+    when( mockJobDetail.getKey() ).thenReturn( jobKey );
+    when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
+    when( mockJobDetail.getJobClass() ).thenReturn( (Class) BlockingQuartzJob.class );
+
+    // Mock Scheduler and related objects
+    Scheduler mockScheduler = mock( Scheduler.class );
+    Trigger mockTrigger = mock( Trigger.class );
+
+    when( mockTrigger.getTriggerBuilder() ).thenAnswer( unused -> TriggerBuilder.newTrigger() );
+    when( mockTrigger.getNextFireTime() ).thenReturn( new Date() );
+
+    when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
+    when( mockScheduler.getTriggersOfJob( jobKey ) )
+      .thenAnswer( unused -> Collections.singletonList( mockTrigger ) );
+
+    // Mock SchedulerFactory
+    SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
+    when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
+
+    // Instantiate QuartzScheduler and set the mock SchedulerFactory
+    QuartzScheduler mockQuartzScheduler = new QuartzScheduler();
+    mockQuartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
+
+    // Act
+    mockQuartzScheduler.saveExecutionDate( jobKey, executionTime );
+
+    // Assert
+    assertEquals( executionTime, jobDataMap.get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
+    verify( mockScheduler ).deleteJob( jobKey );
+    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), any( Trigger.class ) );
+  }
+
+  @Test
+  public void testSaveExecutionDateCalendarIntervalTriggerPreservesSchedule() throws Exception {
+    Date executionTime = new Date();
+    JobDetail mockJobDetail = mock( JobDetail.class );
+    JobKey jobKey = new JobKey( TEST_JOB, TEST_GROUP );
+    JobDataMap jobDataMap = new JobDataMap();
+
+    when( mockJobDetail.getKey() ).thenReturn( jobKey );
+    when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
+    when( mockJobDetail.getJobClass() ).thenReturn( (Class) BlockingQuartzJob.class );
+
+    CalendarIntervalTriggerImpl oldTrigger = new CalendarIntervalTriggerImpl();
+    Date startTime = new Date( System.currentTimeMillis() - 1000 );
+    Date nextFireTime = new Date( System.currentTimeMillis() + 300000 );
+
+    oldTrigger.setKey( new TriggerKey( TEST_TRIGGER, TEST_GROUP ) );
+    oldTrigger.setJobKey( jobKey );
+    oldTrigger.setStartTime( startTime );
+    oldTrigger.setNextFireTime( nextFireTime );
+    oldTrigger.setRepeatInterval( 5 );
+    oldTrigger.setRepeatIntervalUnit( DateBuilder.IntervalUnit.MINUTE );
+    oldTrigger.setTimeZone( TimeZone.getTimeZone( UTC_TIMEZONE ) );
+    oldTrigger.setMisfireInstruction( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_DO_NOTHING );
+
+    Scheduler mockScheduler = mock( Scheduler.class );
+    when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
+    when( mockScheduler.getTriggersOfJob( jobKey ) )
+      .thenAnswer( unused -> Collections.singletonList( oldTrigger ) );
+
+    SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
+    when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
+
+    QuartzScheduler mockQuartzScheduler = new QuartzScheduler();
+    mockQuartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
+
+    mockQuartzScheduler.saveExecutionDate( jobKey, executionTime );
+
+    assertEquals( executionTime, jobDataMap.get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
+    verify( mockScheduler ).deleteJob( jobKey );
+
+    ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass( Trigger.class );
+    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), triggerCaptor.capture() );
+    Trigger scheduledTrigger = triggerCaptor.getValue();
+    assertTrue( scheduledTrigger instanceof CalendarIntervalTriggerImpl );
+    CalendarIntervalTriggerImpl t = (CalendarIntervalTriggerImpl) scheduledTrigger;
+    assertEquals( 5, t.getRepeatInterval() );
+    assertEquals( DateBuilder.IntervalUnit.MINUTE, t.getRepeatIntervalUnit() );
+    assertEquals( UTC_TIMEZONE, t.getTimeZone( ).getID( ) );
+    assertEquals( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_DO_NOTHING, t.getMisfireInstruction() );
+    assertNotNull( t.getStartTime() );
+  }
+
+  @Test
+  public void testSaveExecutionDatePreservesCalendarName() throws Exception {
+    // Arrange: Create a job with CalendarIntervalTrigger and calendar name
+    JobKey jobKey = new JobKey( TEST_JOB, TEST_GROUP );
+
+    Map<String, Object> jobParams = new HashMap<>();
+    jobParams.put( PARAM_KEY, TEST_VALUE );
+    jobParams.put( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME, new Date( System.currentTimeMillis() - 10000 ) );
+
+    JobDetail jobDetail = JobBuilder.newJob( BlockingQuartzJob.class )
+      .withIdentity( jobKey )
+      .usingJobData( new JobDataMap( jobParams ) )
+      .build();
+
+    CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl();
+    trigger.setKey( new TriggerKey( TEST_TRIGGER, TEST_GROUP ) );
+    trigger.setJobKey( jobKey );
+    trigger.setRepeatInterval( 1 );
+    trigger.setRepeatIntervalUnit( org.quartz.DateBuilder.IntervalUnit.HOUR );
+    trigger.setStartTime( new Date() );
+    trigger.setCalendarName( MOCK_CALENDAR_NAME );
+    trigger.setMisfireInstruction( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_FIRE_ONCE_NOW );
+
+    scheduler.scheduleJob( jobDetail, trigger );
+
+    // Act: Call saveExecutionDate
+    Date newExecutionTime = new Date();
+    quartzScheduler.saveExecutionDate( jobKey, newExecutionTime );
+
+    // Assert: Verify calendar name is preserved on new trigger
+    Trigger newTrigger = scheduler.getTriggersOfJob( jobKey ).stream()
+      .filter( t -> !t.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX ) )
+      .findFirst()
+      .orElse( null );
+
+    assertNotNull( TRIGGER_EXISTS_MESSAGE, newTrigger );
+    assertEquals( "Calendar name should be preserved", MOCK_CALENDAR_NAME, newTrigger.getCalendarName( ) );
+  }
+
+  @Test
+  public void testSaveExecutionDateHandlesNullCalendarName() throws Exception {
+    // Arrange: Create a job with trigger without calendar name
+    JobKey jobKey = new JobKey( TEST_JOB, MOCK_TEST_GROUP );
+
+    Map<String, Object> jobParams = new HashMap<>();
+    jobParams.put( PARAM_KEY, TEST_VALUE );
+    jobParams.put( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME, new Date( System.currentTimeMillis() - 10000 ) );
+
+    JobDetail jobDetail = JobBuilder.newJob( BlockingQuartzJob.class )
+      .withIdentity( jobKey )
+      .usingJobData( new JobDataMap( jobParams ) )
+      .build();
+
+    CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl();
+    trigger.setKey( new TriggerKey( TEST_TRIGGER, MOCK_TEST_GROUP ) );
+    trigger.setJobKey( jobKey );
+    trigger.setRepeatInterval( 1 );
+    trigger.setRepeatIntervalUnit( org.quartz.DateBuilder.IntervalUnit.HOUR );
+    trigger.setStartTime( new Date() );
+    trigger.setMisfireInstruction( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_FIRE_ONCE_NOW );
+
+    scheduler.scheduleJob( jobDetail, trigger );
+
+    // Act: Call saveExecutionDate
+    Date newExecutionTime = new Date();
+    quartzScheduler.saveExecutionDate( jobKey, newExecutionTime );
+
+    // Assert: Verify calendar name remains null
+    Trigger newTrigger = scheduler.getTriggersOfJob( jobKey ).stream()
+      .filter( t -> !t.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX ) )
+      .findFirst()
+      .orElse( null );
+
+    assertNotNull( TRIGGER_EXISTS_MESSAGE, newTrigger );
+    assertNull( "Calendar name should be null", newTrigger.getCalendarName() );
+  }
+
+  @Test
+  public void testSaveExecutionDatePreservesScheduleProperties() throws Exception {
+    // Arrange: Create a job with specific schedule properties
+    JobKey jobKey = new JobKey( TEST_JOB, MOCK_TEST_GROUP );
+
+    Map<String, Object> jobParams = new HashMap<>();
+    jobParams.put( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME, new Date( System.currentTimeMillis() - 10000 ) );
+
+    JobDetail jobDetail = JobBuilder.newJob( BlockingQuartzJob.class )
+      .withIdentity( jobKey )
+      .usingJobData( new JobDataMap( jobParams ) )
+      .build();
+
+    CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl();
+    trigger.setKey( new TriggerKey( TEST_TRIGGER, MOCK_TEST_GROUP ) );
+    trigger.setJobKey( jobKey );
+    trigger.setRepeatInterval( 5 );
+    trigger.setRepeatIntervalUnit( org.quartz.DateBuilder.IntervalUnit.MINUTE );
+    trigger.setTimeZone( TimeZone.getTimeZone( UTC_TIMEZONE ) );
+    trigger.setStartTime( new Date() );
+    trigger.setMisfireInstruction( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_DO_NOTHING );
+
+    scheduler.scheduleJob( jobDetail, trigger );
+
+    // Act: Call saveExecutionDate
+    Date newExecutionTime = new Date();
+    quartzScheduler.saveExecutionDate( jobKey, newExecutionTime );
+
+    // Assert: Verify schedule properties are preserved
+    Trigger newTrigger = scheduler.getTriggersOfJob( jobKey ).stream()
+      .filter( t -> !t.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX ) )
+      .findFirst( )
+      .orElse( null );
+
+    assertNotNull( TRIGGER_EXISTS_MESSAGE, newTrigger );
+    assertTrue( "New trigger should be CalendarIntervalTrigger", newTrigger instanceof CalendarIntervalTrigger );
+
+    CalendarIntervalTrigger castedTrigger = ( CalendarIntervalTrigger ) newTrigger;
+    assertEquals( "Repeat interval should be preserved", 5, castedTrigger.getRepeatInterval( ) );
+    assertEquals( "Repeat interval unit should be preserved", org.quartz.DateBuilder.IntervalUnit.MINUTE,
+      castedTrigger.getRepeatIntervalUnit() );
+    assertEquals( "Timezone should be preserved", TimeZone.getTimeZone( UTC_TIMEZONE ), castedTrigger.getTimeZone( ) );
+    assertEquals( "Misfire instruction should be preserved", CalendarIntervalTrigger.MISFIRE_INSTRUCTION_DO_NOTHING,
+      castedTrigger.getMisfireInstruction() );
+  }
+
+  @Test
+  public void testSaveExecutionDateHandlesNonCalendarIntervalTrigger() throws Exception {
+    // Arrange: Create a job with CronTrigger
+    JobKey jobKey = new JobKey( TEST_JOB, MOCK_TEST_GROUP );
+
+    Map<String, Object> jobParams = new HashMap<>();
+    jobParams.put( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME, new Date( System.currentTimeMillis() - 10000 ) );
+
+    JobDetail jobDetail = JobBuilder.newJob( BlockingQuartzJob.class )
+      .withIdentity( jobKey )
+      .usingJobData( new JobDataMap( jobParams ) )
+      .build();
+
+    CronTriggerImpl trigger = new CronTriggerImpl();
+    trigger.setKey( new TriggerKey( "cron-trigger", MOCK_TEST_GROUP ) );
+    trigger.setJobKey( jobKey );
+    trigger.setStartTime( new Date() );
+    trigger.setCalendarName( CRON_CALENDAR_NAME );
+    try {
+      trigger.setCronExpression( "0 0 12 * * ?" );
+    } catch ( Exception e ) {
+      fail( "Failed to set cron expression: " + e.getMessage() );
+    }
+
+    scheduler.scheduleJob( jobDetail, trigger );
+
+    // Act: Call saveExecutionDate
+    Date newExecutionTime = new Date();
+    quartzScheduler.saveExecutionDate( jobKey, newExecutionTime );
+
+    // Assert: Verify calendar name is preserved for CronTrigger
+    Trigger newTrigger = scheduler.getTriggersOfJob( jobKey ).stream()
+      .filter( t -> !t.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX ) )
+      .findFirst( )
+      .orElse( null );
+
+    assertNotNull( TRIGGER_EXISTS_MESSAGE, newTrigger );
+    assertEquals( "Calendar name should be preserved for CronTrigger", CRON_CALENDAR_NAME, newTrigger.getCalendarName( ) );
+  }
+
+  @Test
+  public void testSaveExecutionDateRestoresTriggerPausedState() throws Exception {
+    // Arrange: Create and schedule a job with a paused trigger
+    JobKey jobKey = new JobKey( TEST_JOB, MOCK_TEST_GROUP );
+
+    Map<String, Object> jobParams = new HashMap<>();
+    jobParams.put( PARAM_KEY, TEST_VALUE );
+    jobParams.put( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME, new Date( System.currentTimeMillis() - 10000 ) );
+
+    JobDetail jobDetail = JobBuilder.newJob( BlockingQuartzJob.class )
+      .withIdentity( jobKey )
+      .usingJobData( new JobDataMap( jobParams ) )
+      .build();
+
+    Trigger trigger = TriggerBuilder.newTrigger()
+      .withIdentity( new TriggerKey( TEST_TRIGGER, MOCK_TEST_GROUP ) )
+      .withSchedule( CalendarIntervalScheduleBuilder.calendarIntervalSchedule()
+        .withIntervalInHours( 1 ) )
+      .startAt( new Date() )
+      .build();
+
+    scheduler.scheduleJob( jobDetail, trigger );
+
+    // Pause the trigger to establish initial state
+    scheduler.pauseTrigger( trigger.getKey() );
+
+    // Verify trigger is paused
+    assertEquals( "Trigger should be PAUSED", Trigger.TriggerState.PAUSED,
+      scheduler.getTriggerState( trigger.getKey() ) );
+
+    // Act: Call saveExecutionDate which should preserve the paused state
+    Date newExecutionTime = new Date();
+    quartzScheduler.saveExecutionDate( jobKey, newExecutionTime );
+
+    // Assert: Get the new trigger and verify it's still paused
+    Trigger newTrigger = scheduler.getTriggersOfJob( jobKey ).stream()
+      .filter( t -> !t.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX ) )
+      .findFirst()
+      .orElse( null );
+
+    assertNotNull( TRIGGER_EXISTS_MESSAGE, newTrigger );
+    assertEquals( "New trigger should be PAUSED after saveExecutionDate", Trigger.TriggerState.PAUSED,
+      scheduler.getTriggerState( newTrigger.getKey() ) );
+  }
+}

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerSaveExecutionDateTest.java
@@ -10,6 +10,7 @@ import org.quartz.DateBuilder;
 import org.quartz.JobBuilder;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
 import org.quartz.JobKey;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerFactory;
@@ -25,6 +26,12 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.awaitility.Awaitility.await;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -46,18 +53,43 @@ public class QuartzSchedulerSaveExecutionDateTest {
   private static final String MOCK_TEST_GROUP = "test-group";
   private static final String PARAM_KEY = "key1";
   private static final String UTC_TIMEZONE = "UTC";
-  private static final String MANUAL_TRIGGER_PREFIX = "MT_";
   private static final String MOCK_CALENDAR_NAME = "my-calendar";
   private static final String CRON_CALENDAR_NAME = "cron-calendar";
+  private static final int EXECUTION_TIMEOUT_SECONDS = 5;
 
   private Scheduler scheduler;
   private QuartzScheduler quartzScheduler;
+
+  public static class CountingJob implements org.quartz.Job {
+    private static final AtomicInteger EXECUTIONS = new AtomicInteger();
+    private static final AtomicReference<CountDownLatch> LATCH = new AtomicReference<>( new CountDownLatch( 1 ) );
+
+    static void reset() {
+      EXECUTIONS.set( 0 );
+      LATCH.set( new CountDownLatch( 1 ) );
+    }
+
+    static int getExecutionCount() {
+      return EXECUTIONS.get();
+    }
+
+    static boolean awaitExecution() throws InterruptedException {
+      return LATCH.get().await( EXECUTION_TIMEOUT_SECONDS, TimeUnit.SECONDS );
+    }
+
+    @Override
+    public void execute( JobExecutionContext context ) {
+      EXECUTIONS.incrementAndGet();
+      LATCH.get().countDown();
+    }
+  }
 
   @Before
   public void setUp() throws Exception {
     scheduler = new StdSchedulerFactory().getScheduler();
     scheduler.start();
     quartzScheduler = new QuartzScheduler();
+    CountingJob.reset();
   }
 
   @After
@@ -102,9 +134,12 @@ public class QuartzSchedulerSaveExecutionDateTest {
     mockQuartzScheduler.saveExecutionDate( jobKey, executionTime );
 
     // Assert
-    assertEquals( executionTime, jobDataMap.get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
     verify( mockScheduler ).deleteJob( jobKey );
-    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), any( Trigger.class ) );
+
+    ArgumentCaptor<JobDetail> jobDetailCaptor = ArgumentCaptor.forClass( JobDetail.class );
+    verify( mockScheduler ).scheduleJob( jobDetailCaptor.capture(), any( Trigger.class ) );
+    assertEquals( executionTime,
+      jobDetailCaptor.getValue().getJobDataMap().get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
   }
 
   @Test
@@ -144,11 +179,13 @@ public class QuartzSchedulerSaveExecutionDateTest {
 
     mockQuartzScheduler.saveExecutionDate( jobKey, executionTime );
 
-    assertEquals( executionTime, jobDataMap.get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
     verify( mockScheduler ).deleteJob( jobKey );
 
+    ArgumentCaptor<JobDetail> jobDetailCaptor = ArgumentCaptor.forClass( JobDetail.class );
     ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass( Trigger.class );
-    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), triggerCaptor.capture() );
+    verify( mockScheduler ).scheduleJob( jobDetailCaptor.capture(), triggerCaptor.capture() );
+    assertEquals( executionTime,
+      jobDetailCaptor.getValue().getJobDataMap().get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
     Trigger scheduledTrigger = triggerCaptor.getValue();
     assertTrue( scheduledTrigger instanceof CalendarIntervalTriggerImpl );
     CalendarIntervalTriggerImpl t = (CalendarIntervalTriggerImpl) scheduledTrigger;
@@ -190,7 +227,7 @@ public class QuartzSchedulerSaveExecutionDateTest {
 
     // Assert: Verify calendar name is preserved on new trigger
     Trigger newTrigger = scheduler.getTriggersOfJob( jobKey ).stream()
-      .filter( t -> !t.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX ) )
+      .filter( t -> !quartzScheduler.isManualTrigger( t ) )
       .findFirst()
       .orElse( null );
 
@@ -228,7 +265,7 @@ public class QuartzSchedulerSaveExecutionDateTest {
 
     // Assert: Verify calendar name remains null
     Trigger newTrigger = scheduler.getTriggersOfJob( jobKey ).stream()
-      .filter( t -> !t.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX ) )
+      .filter( t -> !quartzScheduler.isManualTrigger( t ) )
       .findFirst()
       .orElse( null );
 
@@ -266,7 +303,7 @@ public class QuartzSchedulerSaveExecutionDateTest {
 
     // Assert: Verify schedule properties are preserved
     Trigger newTrigger = scheduler.getTriggersOfJob( jobKey ).stream()
-      .filter( t -> !t.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX ) )
+      .filter( t -> !quartzScheduler.isManualTrigger( t ) )
       .findFirst( )
       .orElse( null );
 
@@ -314,7 +351,7 @@ public class QuartzSchedulerSaveExecutionDateTest {
 
     // Assert: Verify calendar name is preserved for CronTrigger
     Trigger newTrigger = scheduler.getTriggersOfJob( jobKey ).stream()
-      .filter( t -> !t.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX ) )
+      .filter( t -> !quartzScheduler.isManualTrigger( t ) )
       .findFirst( )
       .orElse( null );
 
@@ -358,7 +395,7 @@ public class QuartzSchedulerSaveExecutionDateTest {
 
     // Assert: Get the new trigger and verify it's still paused
     Trigger newTrigger = scheduler.getTriggersOfJob( jobKey ).stream()
-      .filter( t -> !t.getKey().getName().startsWith( MANUAL_TRIGGER_PREFIX ) )
+      .filter( t -> !quartzScheduler.isManualTrigger( t ) )
       .findFirst()
       .orElse( null );
 
@@ -366,4 +403,104 @@ public class QuartzSchedulerSaveExecutionDateTest {
     assertEquals( "New trigger should be PAUSED after saveExecutionDate", Trigger.TriggerState.PAUSED,
       scheduler.getTriggerState( newTrigger.getKey() ) );
   }
+
+  @Test
+  public void testTriggerNowExecutesCalendarIntervalJobExactlyOnce() throws Exception {
+    QuartzJobKey quartzJobKey = new QuartzJobKey( TEST_JOB, TEST_GROUP );
+    JobKey jobKey = new JobKey( quartzJobKey.toString(), quartzJobKey.getUserName() );
+    Date lastExecutionTime = new Date( System.currentTimeMillis() - 10_000 );
+
+    JobDataMap jobDataMap = new JobDataMap();
+    jobDataMap.put( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME, lastExecutionTime );
+
+    JobDetail jobDetail = JobBuilder.newJob( CountingJob.class )
+      .withIdentity( jobKey )
+      .usingJobData( jobDataMap )
+      .build();
+
+    CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl();
+    trigger.setKey( new TriggerKey( TEST_TRIGGER, TEST_GROUP ) );
+    trigger.setJobKey( jobKey );
+    trigger.setRepeatInterval( 1 );
+    trigger.setRepeatIntervalUnit( DateBuilder.IntervalUnit.HOUR );
+    trigger.setStartTime( new Date( System.currentTimeMillis() + 60_000 ) );
+    trigger.setMisfireInstruction( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_FIRE_ONCE_NOW );
+
+    scheduler.scheduleJob( jobDetail, trigger );
+
+    SchedulerFactory schedulerFactory = mock( SchedulerFactory.class );
+    when( schedulerFactory.getScheduler() ).thenReturn( scheduler );
+    quartzScheduler.setQuartzSchedulerFactory( schedulerFactory );
+
+    quartzScheduler.triggerNow( jobKey.getName() );
+
+    assertTrue( "Execute Now should fire the job once", CountingJob.awaitExecution() );
+
+    await()
+      .pollInterval( 50, TimeUnit.MILLISECONDS )
+      .during( 750, TimeUnit.MILLISECONDS )
+      .atMost( 1, TimeUnit.SECONDS )
+      .until( () -> CountingJob.getExecutionCount() <= 1 );
+
+    assertEquals( "Execute Now should produce a single execution", 1, CountingJob.getExecutionCount() );
+    assertEquals( "Execute Now should not pre-update Last Run", lastExecutionTime,
+      scheduler.getJobDetail( jobKey ).getJobDataMap().get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
+
+    long manualTriggerCount = scheduler.getTriggersOfJob( jobKey ).stream()
+      .filter( quartzScheduler::isManualTrigger )
+      .count();
+    assertTrue( "Manual trigger handling should remain intact", manualTriggerCount <= 1 );
+  }
+
+  @Test
+  public void testResumeJobDoesNotImmediatelyFirePausedCalendarIntervalSchedule() throws Exception {
+    QuartzJobKey quartzJobKey = new QuartzJobKey( TEST_JOB, TEST_GROUP );
+    JobKey jobKey = new JobKey( quartzJobKey.toString(), quartzJobKey.getUserName() );
+    Date lastExecutionTime = new Date( System.currentTimeMillis() - 10_000 );
+
+    JobDataMap jobDataMap = new JobDataMap();
+    jobDataMap.put( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME, lastExecutionTime );
+
+    JobDetail jobDetail = JobBuilder.newJob( CountingJob.class )
+      .withIdentity( jobKey )
+      .usingJobData( jobDataMap )
+      .build();
+
+    CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl();
+    trigger.setKey( new TriggerKey( TEST_TRIGGER, TEST_GROUP ) );
+    trigger.setJobKey( jobKey );
+    trigger.setRepeatInterval( 1 );
+    trigger.setRepeatIntervalUnit( DateBuilder.IntervalUnit.MINUTE );
+    trigger.setStartTime( new Date( System.currentTimeMillis() + 1_000 ) );
+    trigger.setMisfireInstruction( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_FIRE_ONCE_NOW );
+
+    scheduler.scheduleJob( jobDetail, trigger );
+    scheduler.pauseJob( jobKey );
+
+    // Wait until the trigger's nextFireTime has lapsed so Quartz would normally misfire on resume
+    await()
+      .pollInterval( 100, TimeUnit.MILLISECONDS )
+      .atMost( 5, TimeUnit.SECONDS )
+      .until( () -> {
+        Trigger t = scheduler.getTriggersOfJob( jobKey ).stream().findFirst().orElse( null );
+        return t != null && t.getNextFireTime() != null && t.getNextFireTime().before( new Date() );
+      } );
+
+    SchedulerFactory schedulerFactory = mock( SchedulerFactory.class );
+    when( schedulerFactory.getScheduler() ).thenReturn( scheduler );
+    quartzScheduler.setQuartzSchedulerFactory( schedulerFactory );
+
+    quartzScheduler.resumeJob( jobKey.getName() );
+
+    await()
+      .pollInterval( 50, TimeUnit.MILLISECONDS )
+      .during( 750, TimeUnit.MILLISECONDS )
+      .atMost( 1, TimeUnit.SECONDS )
+      .until( () -> CountingJob.getExecutionCount() == 0 );
+
+    assertEquals( "Resume should not immediately execute a paused schedule", 0, CountingJob.getExecutionCount() );
+    assertEquals( "Resume should not pre-update Last Run", lastExecutionTime,
+      scheduler.getJobDetail( jobKey ).getJobDataMap().get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
+  }
+
 }

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
@@ -24,18 +24,14 @@ import org.pentaho.platform.api.scheduler2.Job;
 import org.pentaho.platform.api.scheduler2.SchedulerException;
 import org.pentaho.platform.api.scheduler2.SimpleJobTrigger;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
-import org.quartz.CalendarIntervalTrigger;
 import org.quartz.CronExpression;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.CronTrigger;
-import org.quartz.DateBuilder;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerFactory;
-import org.quartz.SimpleScheduleBuilder;
-import org.quartz.SimpleTrigger;
 import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
 import org.quartz.TriggerKey;
@@ -360,12 +356,7 @@ public class QuartzSchedulerTest {
   public void testCreateQuartzTriggerWithSimpleJobTrigger() throws Exception {
     // Arrange
     SimpleJobTrigger simpleTrigger = new SimpleJobTrigger();
-    Calendar expectedStart = Calendar.getInstance();
-    expectedStart.set( 2025, Calendar.APRIL, 17, 14, 23, 0 );
-    expectedStart.set( Calendar.MILLISECOND, 0 );
-    Date expectedStartDate = expectedStart.getTime();
-
-    simpleTrigger.setStartTime( expectedStartDate );
+    simpleTrigger.setStartTime( new Date() );
     simpleTrigger.setRepeatInterval( 1000 );
     simpleTrigger.setRepeatCount( 5 );
     simpleTrigger.setUiPassParam( "SECONDS" );
@@ -379,14 +370,6 @@ public class QuartzSchedulerTest {
     assertNotNull( quartzTrigger );
     assertTrue( quartzTrigger instanceof CalendarIntervalTriggerImpl );
     assertEquals( 1000, ( (CalendarIntervalTriggerImpl) quartzTrigger ).getRepeatInterval() );
-
-    Calendar actualStart = Calendar.getInstance();
-    actualStart.setTime( ( (CalendarIntervalTriggerImpl) quartzTrigger ).getStartTime() );
-    assertEquals( expectedStart.get( Calendar.MINUTE ), actualStart.get( Calendar.MINUTE ) );
-    assertEquals( expectedStart.get( Calendar.HOUR_OF_DAY ), actualStart.get( Calendar.HOUR_OF_DAY ) );
-    assertEquals( expectedStart.get( Calendar.DAY_OF_MONTH ), actualStart.get( Calendar.DAY_OF_MONTH ) );
-    assertEquals( expectedStart.get( Calendar.MONTH ), actualStart.get( Calendar.MONTH ) );
-    assertEquals( expectedStart.get( Calendar.YEAR ), actualStart.get( Calendar.YEAR ) );
   }
 
   @Test
@@ -407,7 +390,7 @@ public class QuartzSchedulerTest {
   }
 
   @Test
-  public void testTriggerNowUpdatesJobData() throws Exception {
+  public void testTriggerNow() throws Exception {
     // Arrange
     // Mock JobDetail and related objects
     JobDetail mockJobDetail = mock( JobDetail.class );
@@ -416,20 +399,10 @@ public class QuartzSchedulerTest {
 
     when( mockJobDetail.getKey() ).thenReturn( jobKey );
     when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
-    when( mockJobDetail.getJobClass() )
-      .thenAnswer( unused -> BlockingQuartzJob.class );
 
     // Mock Scheduler and related objects
     Scheduler mockScheduler = mock( Scheduler.class );
-    Trigger mockTrigger = mock( Trigger.class );
-
-    when( mockTrigger.getTriggerBuilder() ).thenAnswer( unused -> TriggerBuilder.newTrigger() );
-    when( mockTrigger.getNextFireTime() ).thenReturn( new Date());
-
-    when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
-    when( mockScheduler.getTriggersOfJob( jobKey ) )
-      .thenAnswer( unused -> Collections.singletonList( mockTrigger ) );
-
+    
     // Mock SchedulerFactory
     SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
 
@@ -443,23 +416,18 @@ public class QuartzSchedulerTest {
     quartzScheduler.triggerNow( "testJob\ttestGroup\trandomUuid" );
 
     // Assert
-    assertNotNull( jobDataMap.get( QuartzScheduler.RESERVEDMAPKEY_PREVIOUS_TRIGGER_NOW ) );
-    verify( mockScheduler ).deleteJob( jobKey );
-    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), any( Trigger.class ) );
+    // Verify that triggerJob is called (the actual execution timestamp
+    // will be recorded by BlockingQuartzJob.recordExecutionTime() after execution)
     verify( mockScheduler ).triggerJob( jobKey );
   }
 
   @Test
-  public void testGetLastRun_PreviousTriggerNowLater() throws Exception {
+  public void testGetLastRun_ReturnsNull() throws Exception {
     // Arrange
-    // Mock JobDetail and related objects
-    Date previousTriggerNow = new Date( System.currentTimeMillis() - 1000 );
-    Date previousFireTime = new Date( System.currentTimeMillis() - 2000 );
-
+    // Test that when no LAST_EXECUTION_TIME is present, the method returns null
     JobDetail mockJobDetail = mock( JobDetail.class );
     JobKey jobKey = new JobKey( "testJob\ttestGroup\trandomUuid", "testJob" );
     JobDataMap jobDataMap = new JobDataMap();
-    jobDataMap.put( QuartzScheduler.RESERVEDMAPKEY_PREVIOUS_TRIGGER_NOW, previousTriggerNow );
 
     when( mockJobDetail.getKey() ).thenReturn( jobKey );
     when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
@@ -469,7 +437,6 @@ public class QuartzSchedulerTest {
     Trigger mockTrigger = mock( Trigger.class );
 
     when( mockTrigger.getJobKey() ).thenReturn( jobKey );
-    when( mockTrigger.getPreviousFireTime() ).thenReturn( previousFireTime );
     when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
 
     // Mock SchedulerFactory
@@ -484,154 +451,20 @@ public class QuartzSchedulerTest {
     // Act
     Date lastRun = quartzScheduler.getLastRun( mockTrigger );
 
-    // Assert
-    assertEquals( previousTriggerNow, lastRun );
-  }
-
-  @Test
-  public void testGetLastRun_PreviousTriggerNowAbsent() throws Exception {
-    // Arrange
-    // Mock JobDetail and related objects
-    Date previousFireTime = new Date( System.currentTimeMillis() - 2000 );
-
-    JobDetail mockJobDetail = mock( JobDetail.class );
-    JobKey jobKey = new JobKey( "testJob\ttestGroup\trandomUuid", "testJob" );
-    JobDataMap jobDataMap = new JobDataMap();
-
-    when( mockJobDetail.getKey() ).thenReturn( jobKey );
-    when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
-
-    // Mock Scheduler and related objects
-    Scheduler mockScheduler = mock( Scheduler.class );
-    Trigger mockTrigger = mock( Trigger.class );
-
-    when( mockTrigger.getJobKey() ).thenReturn( jobKey );
-    when( mockTrigger.getPreviousFireTime() ).thenReturn( previousFireTime );
-    when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
-
-    // Mock SchedulerFactory
-    SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
-
-    when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
-
-    // Instantiate QuartzScheduler and set the mock SchedulerFactory
-    QuartzScheduler quartzScheduler = new QuartzScheduler();
-    quartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
-
-    // Act
-    Date lastRun = quartzScheduler.getLastRun( mockTrigger );
-
-    // Assert
-    assertEquals( previousFireTime, lastRun );
-  }
-
-  @Test
-  public void testGetJob_WithSimpleTrigger_MapsSimpleJobTriggerFields() throws Exception {
-    // Arrange
-    String jobId = "testJob\ttestGroup\trandomUuid";
-    JobKey quartzJobKey = new JobKey( jobId, "testJob" );
-    Date startTime = new Date( 125, Calendar.APRIL, 17, 14, 23, 0 );
-    Date endTime = new Date( 125, Calendar.APRIL, 20, 9, 45, 0 );
-
-    SimpleTrigger simpleTrigger = TriggerBuilder.newTrigger()
-      .withIdentity( "testTrigger", "testJob" )
-      .forJob( quartzJobKey )
-      .startAt( startTime )
-      .endAt( endTime )
-      .withSchedule( SimpleScheduleBuilder.simpleSchedule().withIntervalInMilliseconds( 15000L ).withRepeatCount( 7 ) )
-      .build();
-
-    JobDataMap jobDataMap = new JobDataMap();
-    jobDataMap.put( QuartzScheduler.RESERVEDMAPKEY_UIPASSPARAM, QuartzScheduler.UI_PASS_PARAM_SECONDS );
-    //jobDataMap.put( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME, new Date( startTime.getTime() - 60000 ) );
-
-    JobDetail mockJobDetail = mock( JobDetail.class );
-    when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
-    when( mockJobDetail.getKey() ).thenReturn( quartzJobKey );
-
-    Scheduler mockScheduler = mock( Scheduler.class );
-    Mockito.doReturn( Collections.singletonList( simpleTrigger ) )
-      .when( mockScheduler ).getTriggersOfJob( any( JobKey.class ) );
-    when( mockScheduler.getJobDetail( any( JobKey.class ) ) ).thenReturn( mockJobDetail );
-    when( mockScheduler.getTriggerState( any( TriggerKey.class ) ) ).thenReturn( Trigger.TriggerState.NORMAL );
-
-    SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
-    when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
-
-    QuartzScheduler quartzScheduler = new QuartzScheduler();
-    quartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
-
-    // Act
-    Job job = quartzScheduler.getJob( jobId );
-
-    // Assert
-    assertNotNull( job );
-    assertTrue( job.getJobTrigger() instanceof SimpleJobTrigger );
-
-    SimpleJobTrigger mappedTrigger = (SimpleJobTrigger) job.getJobTrigger();
-    int expectedHour = startTime.getHours();
-    if ( expectedHour > 12 ) {
-      expectedHour -= 12;
-    }
-
-    assertEquals( startTime, mappedTrigger.getStartTime() );
-    assertEquals( endTime, mappedTrigger.getEndTime() );
-    assertEquals( expectedHour, mappedTrigger.getStartHour() );
-    assertEquals( startTime.getMinutes(), mappedTrigger.getStartMin() );
-    assertEquals( startTime.getYear() + 1900, mappedTrigger.getStartYear() );
-    assertEquals( startTime.getMonth() - 1, mappedTrigger.getStartMonth() );
-    assertEquals( startTime.getDate(), mappedTrigger.getStartDay() );
-    assertEquals( QuartzScheduler.UI_PASS_PARAM_SECONDS, mappedTrigger.getUiPassParam() );
-    assertEquals( 15L, mappedTrigger.getRepeatInterval() );
-    assertEquals( 7, mappedTrigger.getRepeatCount() );
-  }
-
-  @Test
-  public void testGetLastRun_BothNull() throws Exception {
-    // Arrange
-    // Mock JobDetail and related objects
-    JobDetail mockJobDetail = mock( JobDetail.class );
-    JobKey jobKey = new JobKey( "testJob\ttestGroup\trandomUuid", "testJob" );
-    JobDataMap jobDataMap = new JobDataMap();
-
-    when( mockJobDetail.getKey() ).thenReturn( jobKey );
-    when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
-
-    // Mock Scheduler and related objects
-    Scheduler mockScheduler = mock( Scheduler.class );
-    Trigger mockTrigger = mock( Trigger.class );
-
-    when( mockTrigger.getJobKey() ).thenReturn( jobKey );
-    when( mockTrigger.getPreviousFireTime() ).thenReturn( null );
-    when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
-
-    // Mock SchedulerFactory
-    SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
-
-    when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
-
-    // Instantiate QuartzScheduler and set the mock SchedulerFactory
-    QuartzScheduler quartzScheduler = new QuartzScheduler();
-    quartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
-
-    // Act
-    Date lastRun = quartzScheduler.getLastRun( mockTrigger );
-
-    // Assert
+    // Assert - Should return null when no execution time is recorded
     assertNull( lastRun );
   }
 
   @Test
-  public void testGetLastRun_PreviousTriggerNowEarlier() throws Exception {
+  public void testGetLastRun_LastExecutionTimePresent() throws Exception {
     // Arrange
-    // Mock JobDetail and related objects
-    Date previousTriggerNow = new Date( System.currentTimeMillis() - 2000 );
-    Date previousFireTime = new Date( System.currentTimeMillis() - 1000 );
+    // Test that LAST_EXECUTION_TIME is returned when present
+    Date lastExecutionTime = new Date( System.currentTimeMillis() - 500 );
 
     JobDetail mockJobDetail = mock( JobDetail.class );
     JobKey jobKey = new JobKey( "testJob\ttestGroup\trandomUuid", "testJob" );
     JobDataMap jobDataMap = new JobDataMap();
-    jobDataMap.put( QuartzScheduler.RESERVEDMAPKEY_PREVIOUS_TRIGGER_NOW, previousTriggerNow );
+    jobDataMap.put( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME, lastExecutionTime );
 
     when( mockJobDetail.getKey() ).thenReturn( jobKey );
     when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
@@ -641,12 +474,10 @@ public class QuartzSchedulerTest {
     Trigger mockTrigger = mock( Trigger.class );
 
     when( mockTrigger.getJobKey() ).thenReturn( jobKey );
-    when( mockTrigger.getPreviousFireTime() ).thenReturn( previousFireTime );
     when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
 
     // Mock SchedulerFactory
     SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
-
     when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
 
     // Instantiate QuartzScheduler and set the mock SchedulerFactory
@@ -656,12 +487,13 @@ public class QuartzSchedulerTest {
     // Act
     Date lastRun = quartzScheduler.getLastRun( mockTrigger );
 
-    // Assert
-    assertEquals( previousFireTime, lastRun );
+    // Assert - LAST_EXECUTION_TIME should be returned
+    assertEquals( lastExecutionTime, lastRun );
   }
 
   @Test
-  public void testSaveExecutionDate_CalendarIntervalTriggerPreservesSchedule() throws Exception {
+  public void testSaveExecutionDate() throws Exception {
+    // Arrange
     Date executionTime = new Date();
     JobDetail mockJobDetail = mock( JobDetail.class );
     JobKey jobKey = new JobKey( "testJob", "testGroup" );
@@ -671,45 +503,31 @@ public class QuartzSchedulerTest {
     when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
     when( mockJobDetail.getJobClass() ).thenReturn( (Class) BlockingQuartzJob.class );
 
-    CalendarIntervalTriggerImpl oldTrigger = new CalendarIntervalTriggerImpl();
-    Date startTime = new Date( System.currentTimeMillis() - 1000 );
-    Date nextFireTime = new Date( System.currentTimeMillis() + 300000 );
-
-    oldTrigger.setKey( new TriggerKey( "testTrigger", "testGroup" ) );
-    oldTrigger.setJobKey( jobKey );
-    oldTrigger.setStartTime( startTime );
-    oldTrigger.setNextFireTime( nextFireTime );
-    oldTrigger.setRepeatInterval( 5 );
-    oldTrigger.setRepeatIntervalUnit( DateBuilder.IntervalUnit.MINUTE );
-    oldTrigger.setTimeZone( TimeZone.getTimeZone( "UTC" ) );
-    oldTrigger.setMisfireInstruction( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_DO_NOTHING );
-
+    // Mock Scheduler and related objects
     Scheduler mockScheduler = mock( Scheduler.class );
+    Trigger mockTrigger = mock( Trigger.class );
+    
+    when( mockTrigger.getTriggerBuilder() ).thenAnswer( unused -> TriggerBuilder.newTrigger() );
+    when( mockTrigger.getNextFireTime() ).thenReturn( new Date() );
+
     when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
     when( mockScheduler.getTriggersOfJob( jobKey ) )
-      .thenAnswer( unused -> Collections.singletonList( oldTrigger ) );
+      .thenAnswer( unused -> Collections.singletonList( mockTrigger ) );
 
+    // Mock SchedulerFactory
     SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
     when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
 
+    // Instantiate QuartzScheduler and set the mock SchedulerFactory
     QuartzScheduler quartzScheduler = new QuartzScheduler();
     quartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
 
+    // Act
     quartzScheduler.saveExecutionDate( jobKey, executionTime );
 
+    // Assert
     assertEquals( executionTime, jobDataMap.get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
     verify( mockScheduler ).deleteJob( jobKey );
-
-    ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass( Trigger.class );
-    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), triggerCaptor.capture() );
-    Trigger scheduledTrigger = triggerCaptor.getValue();
-    assertTrue( scheduledTrigger instanceof CalendarIntervalTriggerImpl );
-    CalendarIntervalTriggerImpl t = (CalendarIntervalTriggerImpl) scheduledTrigger;
-    assertEquals( 5, t.getRepeatInterval() );
-    assertEquals( DateBuilder.IntervalUnit.MINUTE, t.getRepeatIntervalUnit() );
-    assertEquals( "UTC", t.getTimeZone().getID() );
-    assertEquals( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_DO_NOTHING, t.getMisfireInstruction() );
-    assertNotNull( t.getStartTime() );
+    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), any( Trigger.class ) );
   }
-
 }

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
@@ -24,9 +24,11 @@ import org.pentaho.platform.api.scheduler2.Job;
 import org.pentaho.platform.api.scheduler2.SchedulerException;
 import org.pentaho.platform.api.scheduler2.SimpleJobTrigger;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.quartz.CalendarIntervalTrigger;
 import org.quartz.CronExpression;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.CronTrigger;
+import org.quartz.DateBuilder;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
@@ -53,13 +55,16 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.pentaho.platform.api.scheduler2.IScheduler.RESERVEDMAPKEY_ACTIONUSER;
 
 public class QuartzSchedulerTest {
+
+  private static final String TEST_CRON_EXPRESSION = "0 0/5 * * * ?";
+  private static final String TEST_JOB_ID = "testJob\ttestGroup\trandomUuid";
+  private static final String TEST_JOB_GROUP = "testJob";
 
 
   private static IUnifiedRepository repo;
@@ -356,7 +361,12 @@ public class QuartzSchedulerTest {
   public void testCreateQuartzTriggerWithSimpleJobTrigger() throws Exception {
     // Arrange
     SimpleJobTrigger simpleTrigger = new SimpleJobTrigger();
-    simpleTrigger.setStartTime( new Date() );
+    Calendar expectedStart = Calendar.getInstance();
+    expectedStart.set( 2025, Calendar.APRIL, 17, 14, 23, 0 );
+    expectedStart.set( Calendar.MILLISECOND, 0 );
+    Date expectedStartDate = expectedStart.getTime();
+
+    simpleTrigger.setStartTime( expectedStartDate );
     simpleTrigger.setRepeatInterval( 1000 );
     simpleTrigger.setRepeatCount( 5 );
     simpleTrigger.setUiPassParam( "SECONDS" );
@@ -370,13 +380,21 @@ public class QuartzSchedulerTest {
     assertNotNull( quartzTrigger );
     assertTrue( quartzTrigger instanceof CalendarIntervalTriggerImpl );
     assertEquals( 1000, ( (CalendarIntervalTriggerImpl) quartzTrigger ).getRepeatInterval() );
+
+    Calendar actualStart = Calendar.getInstance();
+    actualStart.setTime( ( (CalendarIntervalTriggerImpl) quartzTrigger ).getStartTime() );
+    assertEquals( expectedStart.get( Calendar.MINUTE ), actualStart.get( Calendar.MINUTE ) );
+    assertEquals( expectedStart.get( Calendar.HOUR_OF_DAY ), actualStart.get( Calendar.HOUR_OF_DAY ) );
+    assertEquals( expectedStart.get( Calendar.DAY_OF_MONTH ), actualStart.get( Calendar.DAY_OF_MONTH ) );
+    assertEquals( expectedStart.get( Calendar.MONTH ), actualStart.get( Calendar.MONTH ) );
+    assertEquals( expectedStart.get( Calendar.YEAR ), actualStart.get( Calendar.YEAR ) );
   }
 
   @Test
   public void testCreateQuartzTriggerWithComplexJobTrigger() throws Exception {
     // Arrange
     ComplexJobTrigger complexTrigger = new ComplexJobTrigger();
-    complexTrigger.setCronString( "0 0/5 * * * ?" );
+    complexTrigger.setCronString( TEST_CRON_EXPRESSION );
 
     QuartzJobKey jobKey = new QuartzJobKey( "testJob", "testUser" );
 
@@ -386,7 +404,7 @@ public class QuartzSchedulerTest {
     // Assert
     assertNotNull( quartzTrigger );
     assertTrue( quartzTrigger instanceof CronTriggerImpl );
-    assertEquals( "0 0/5 * * * ?", ((CronTriggerImpl) quartzTrigger).getCronExpression() );
+    assertEquals( TEST_CRON_EXPRESSION, ((CronTriggerImpl) quartzTrigger).getCronExpression() );
   }
 
   @Test
@@ -394,7 +412,7 @@ public class QuartzSchedulerTest {
     // Arrange
     // Mock JobDetail and related objects
     JobDetail mockJobDetail = mock( JobDetail.class );
-    JobKey jobKey = new JobKey( "testJob\ttestGroup\trandomUuid", "testJob" );
+    JobKey jobKey = new JobKey( TEST_JOB_ID, TEST_JOB_GROUP );
     JobDataMap jobDataMap = new JobDataMap();
 
     when( mockJobDetail.getKey() ).thenReturn( jobKey );
@@ -402,7 +420,7 @@ public class QuartzSchedulerTest {
 
     // Mock Scheduler and related objects
     Scheduler mockScheduler = mock( Scheduler.class );
-    
+
     // Mock SchedulerFactory
     SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
 
@@ -413,7 +431,7 @@ public class QuartzSchedulerTest {
     quartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
 
     // Act
-    quartzScheduler.triggerNow( "testJob\ttestGroup\trandomUuid" );
+    quartzScheduler.triggerNow( TEST_JOB_ID );
 
     // Assert
     // Verify that triggerJob is called (the actual execution timestamp
@@ -422,11 +440,98 @@ public class QuartzSchedulerTest {
   }
 
   @Test
+  public void testResumeJobNormalizesPastCalendarIntervalTriggerToFutureFireTime() throws Exception {
+    JobKey jobKey = new JobKey( TEST_JOB_ID, TEST_JOB_GROUP );
+    JobDataMap jobDataMap = new JobDataMap();
+
+    JobDetail mockJobDetail = mock( JobDetail.class );
+    when( mockJobDetail.getKey() ).thenReturn( jobKey );
+    when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
+    when( mockJobDetail.getJobClass() ).thenReturn( (Class) BlockingQuartzJob.class );
+    when( mockJobDetail.isDurable() ).thenReturn( false );
+    when( mockJobDetail.requestsRecovery() ).thenReturn( false );
+
+    // Start time 3 minutes in the past, interval 2 minutes -> nextFireTime is stale (in the past),
+    // but getFireTimeAfter(now) will compute a future time based on the interval.
+    CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl();
+    trigger.setKey( new TriggerKey( "scheduled-trigger", jobKey.getGroup() ) );
+    trigger.setJobKey( jobKey );
+    trigger.setStartTime( new Date( System.currentTimeMillis() - 180_000 ) );
+    trigger.setNextFireTime( new Date( System.currentTimeMillis() - 60_000 ) );
+    trigger.setRepeatInterval( 2 );
+    trigger.setRepeatIntervalUnit( DateBuilder.IntervalUnit.MINUTE );
+    trigger.setMisfireInstruction( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_FIRE_ONCE_NOW );
+    trigger.setTimeZone( TimeZone.getTimeZone( "UTC" ) );
+
+    Scheduler mockScheduler = mock( Scheduler.class );
+    when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
+    when( mockScheduler.getTriggersOfJob( jobKey ) ).thenAnswer( unused -> Collections.singletonList( trigger ) );
+    when( mockScheduler.getTriggerState( trigger.getKey() ) ).thenReturn( Trigger.TriggerState.PAUSED );
+
+    SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
+    when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
+
+    QuartzScheduler quartzScheduler = new QuartzScheduler();
+    quartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
+
+    quartzScheduler.resumeJob( TEST_JOB_ID );
+
+    ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass( Trigger.class );
+    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), triggerCaptor.capture() );
+    verify( mockScheduler ).pauseTrigger( triggerCaptor.getValue().getKey() );
+    verify( mockScheduler ).resumeJob( jobKey );
+
+    assertTrue( triggerCaptor.getValue() instanceof CalendarIntervalTrigger );
+    assertTrue( "Normalized start time should be in the future",
+      triggerCaptor.getValue().getStartTime().after( new Date() ) );
+  }
+
+  @Test
+  public void testResumeJobPreservesCronTriggerCalendarName() throws Exception {
+    JobKey jobKey = new JobKey( TEST_JOB_ID, TEST_JOB_GROUP );
+    JobDataMap jobDataMap = new JobDataMap();
+
+    JobDetail mockJobDetail = mock( JobDetail.class );
+    when( mockJobDetail.getKey() ).thenReturn( jobKey );
+    when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
+    when( mockJobDetail.getJobClass() ).thenReturn( (Class) BlockingQuartzJob.class );
+    when( mockJobDetail.isDurable() ).thenReturn( false );
+    when( mockJobDetail.requestsRecovery() ).thenReturn( false );
+
+    CronTriggerImpl trigger = new CronTriggerImpl();
+    trigger.setKey( new TriggerKey( "cron-trigger", jobKey.getGroup() ) );
+    trigger.setJobKey( jobKey );
+    trigger.setStartTime( new Date( System.currentTimeMillis() - 1_000 ) );
+    trigger.setNextFireTime( new Date( System.currentTimeMillis() + 60_000 ) );
+    trigger.setCalendarName( "cron-calendar" );
+    trigger.setCronExpression( TEST_CRON_EXPRESSION );
+
+    Scheduler mockScheduler = mock( Scheduler.class );
+    when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
+    when( mockScheduler.getTriggersOfJob( jobKey ) ).thenAnswer( unused -> Collections.singletonList( trigger ) );
+    when( mockScheduler.getTriggerState( trigger.getKey() ) ).thenReturn( Trigger.TriggerState.PAUSED );
+
+    SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
+    when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
+
+    QuartzScheduler quartzScheduler = new QuartzScheduler();
+    quartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
+
+    quartzScheduler.resumeJob( TEST_JOB_ID );
+
+    ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass( Trigger.class );
+    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), triggerCaptor.capture() );
+    verify( mockScheduler ).resumeJob( jobKey );
+    assertTrue( triggerCaptor.getValue() instanceof CronTrigger );
+    assertEquals( trigger.getCalendarName(), triggerCaptor.getValue().getCalendarName() );
+  }
+
+  @Test
   public void testGetLastRun_ReturnsNull() throws Exception {
     // Arrange
     // Test that when no LAST_EXECUTION_TIME is present, the method returns null
     JobDetail mockJobDetail = mock( JobDetail.class );
-    JobKey jobKey = new JobKey( "testJob\ttestGroup\trandomUuid", "testJob" );
+    JobKey jobKey = new JobKey( TEST_JOB_ID, TEST_JOB_GROUP );
     JobDataMap jobDataMap = new JobDataMap();
 
     when( mockJobDetail.getKey() ).thenReturn( jobKey );
@@ -462,7 +567,7 @@ public class QuartzSchedulerTest {
     Date lastExecutionTime = new Date( System.currentTimeMillis() - 500 );
 
     JobDetail mockJobDetail = mock( JobDetail.class );
-    JobKey jobKey = new JobKey( "testJob\ttestGroup\trandomUuid", "testJob" );
+    JobKey jobKey = new JobKey( TEST_JOB_ID, TEST_JOB_GROUP );
     JobDataMap jobDataMap = new JobDataMap();
     jobDataMap.put( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME, lastExecutionTime );
 
@@ -489,6 +594,52 @@ public class QuartzSchedulerTest {
 
     // Assert - LAST_EXECUTION_TIME should be returned
     assertEquals( lastExecutionTime, lastRun );
+  }
+
+  @Test
+  public void testSaveExecutionDate() throws Exception {
+    // Arrange
+    Date executionTime = new Date();
+    Date nextFireTime = new Date( System.currentTimeMillis() + 60_000 );
+    JobDetail mockJobDetail = mock( JobDetail.class );
+    JobKey jobKey = new JobKey( "testJob", "testGroup" );
+    JobDataMap jobDataMap = new JobDataMap();
+    TriggerKey triggerKey = new TriggerKey( "scheduled-trigger", "testGroup" );
+
+    when( mockJobDetail.getKey() ).thenReturn( jobKey );
+    when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
+    when( mockJobDetail.getJobClass() ).thenReturn( (Class) BlockingQuartzJob.class );
+
+    // Mock Scheduler and related objects
+    Scheduler mockScheduler = mock( Scheduler.class );
+    Trigger mockTrigger = mock( Trigger.class );
+
+    when( mockTrigger.getTriggerBuilder() ).thenAnswer( unused -> TriggerBuilder.newTrigger() );
+    when( mockTrigger.getNextFireTime() ).thenReturn( nextFireTime );
+    when( mockTrigger.getKey() ).thenReturn( triggerKey );
+
+    when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
+    when( mockScheduler.getTriggersOfJob( jobKey ) )
+      .thenAnswer( unused -> Collections.singletonList( mockTrigger ) );
+    when( mockScheduler.getTriggerState( triggerKey ) ).thenReturn( Trigger.TriggerState.NORMAL );
+
+    // Mock SchedulerFactory
+    SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
+    when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
+
+    // Instantiate QuartzScheduler and set the mock SchedulerFactory
+    QuartzScheduler quartzScheduler = new QuartzScheduler();
+    quartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
+
+    // Act
+    quartzScheduler.saveExecutionDate( jobKey, executionTime );
+
+    // Assert
+    ArgumentCaptor<JobDetail> jobDetailCaptor = ArgumentCaptor.forClass( JobDetail.class );
+    verify( mockScheduler ).deleteJob( jobKey );
+    verify( mockScheduler ).scheduleJob( jobDetailCaptor.capture(), any( Trigger.class ) );
+    assertEquals( executionTime,
+      jobDetailCaptor.getValue().getJobDataMap().get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
   }
 
 }

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
@@ -491,43 +491,4 @@ public class QuartzSchedulerTest {
     assertEquals( lastExecutionTime, lastRun );
   }
 
-  @Test
-  public void testSaveExecutionDate() throws Exception {
-    // Arrange
-    Date executionTime = new Date();
-    JobDetail mockJobDetail = mock( JobDetail.class );
-    JobKey jobKey = new JobKey( "testJob", "testGroup" );
-    JobDataMap jobDataMap = new JobDataMap();
-
-    when( mockJobDetail.getKey() ).thenReturn( jobKey );
-    when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
-    when( mockJobDetail.getJobClass() ).thenReturn( (Class) BlockingQuartzJob.class );
-
-    // Mock Scheduler and related objects
-    Scheduler mockScheduler = mock( Scheduler.class );
-    Trigger mockTrigger = mock( Trigger.class );
-    
-    when( mockTrigger.getTriggerBuilder() ).thenAnswer( unused -> TriggerBuilder.newTrigger() );
-    when( mockTrigger.getNextFireTime() ).thenReturn( new Date() );
-
-    when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
-    when( mockScheduler.getTriggersOfJob( jobKey ) )
-      .thenAnswer( unused -> Collections.singletonList( mockTrigger ) );
-
-    // Mock SchedulerFactory
-    SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
-    when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
-
-    // Instantiate QuartzScheduler and set the mock SchedulerFactory
-    QuartzScheduler quartzScheduler = new QuartzScheduler();
-    quartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
-
-    // Act
-    quartzScheduler.saveExecutionDate( jobKey, executionTime );
-
-    // Assert
-    assertEquals( executionTime, jobDataMap.get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
-    verify( mockScheduler ).deleteJob( jobKey );
-    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), any( Trigger.class ) );
-  }
 }

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/QuartzSchedulerTest.java
@@ -24,9 +24,11 @@ import org.pentaho.platform.api.scheduler2.Job;
 import org.pentaho.platform.api.scheduler2.SchedulerException;
 import org.pentaho.platform.api.scheduler2.SimpleJobTrigger;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.quartz.CalendarIntervalTrigger;
 import org.quartz.CronExpression;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.CronTrigger;
+import org.quartz.DateBuilder;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
@@ -657,4 +659,57 @@ public class QuartzSchedulerTest {
     // Assert
     assertEquals( previousFireTime, lastRun );
   }
+
+  @Test
+  public void testSaveExecutionDate_CalendarIntervalTriggerPreservesSchedule() throws Exception {
+    Date executionTime = new Date();
+    JobDetail mockJobDetail = mock( JobDetail.class );
+    JobKey jobKey = new JobKey( "testJob", "testGroup" );
+    JobDataMap jobDataMap = new JobDataMap();
+
+    when( mockJobDetail.getKey() ).thenReturn( jobKey );
+    when( mockJobDetail.getJobDataMap() ).thenReturn( jobDataMap );
+    when( mockJobDetail.getJobClass() ).thenReturn( (Class) BlockingQuartzJob.class );
+
+    CalendarIntervalTriggerImpl oldTrigger = new CalendarIntervalTriggerImpl();
+    Date startTime = new Date( System.currentTimeMillis() - 1000 );
+    Date nextFireTime = new Date( System.currentTimeMillis() + 300000 );
+
+    oldTrigger.setKey( new TriggerKey( "testTrigger", "testGroup" ) );
+    oldTrigger.setJobKey( jobKey );
+    oldTrigger.setStartTime( startTime );
+    oldTrigger.setNextFireTime( nextFireTime );
+    oldTrigger.setRepeatInterval( 5 );
+    oldTrigger.setRepeatIntervalUnit( DateBuilder.IntervalUnit.MINUTE );
+    oldTrigger.setTimeZone( TimeZone.getTimeZone( "UTC" ) );
+    oldTrigger.setMisfireInstruction( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_DO_NOTHING );
+
+    Scheduler mockScheduler = mock( Scheduler.class );
+    when( mockScheduler.getJobDetail( jobKey ) ).thenReturn( mockJobDetail );
+    when( mockScheduler.getTriggersOfJob( jobKey ) )
+      .thenAnswer( unused -> Collections.singletonList( oldTrigger ) );
+
+    SchedulerFactory mockSchedulerFactory = mock( SchedulerFactory.class );
+    when( mockSchedulerFactory.getScheduler() ).thenReturn( mockScheduler );
+
+    QuartzScheduler quartzScheduler = new QuartzScheduler();
+    quartzScheduler.setQuartzSchedulerFactory( mockSchedulerFactory );
+
+    quartzScheduler.saveExecutionDate( jobKey, executionTime );
+
+    assertEquals( executionTime, jobDataMap.get( QuartzScheduler.RESERVEDMAPKEY_LAST_EXECUTION_TIME ) );
+    verify( mockScheduler ).deleteJob( jobKey );
+
+    ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass( Trigger.class );
+    verify( mockScheduler ).scheduleJob( any( JobDetail.class ), triggerCaptor.capture() );
+    Trigger scheduledTrigger = triggerCaptor.getValue();
+    assertTrue( scheduledTrigger instanceof CalendarIntervalTriggerImpl );
+    CalendarIntervalTriggerImpl t = (CalendarIntervalTriggerImpl) scheduledTrigger;
+    assertEquals( 5, t.getRepeatInterval() );
+    assertEquals( DateBuilder.IntervalUnit.MINUTE, t.getRepeatIntervalUnit() );
+    assertEquals( "UTC", t.getTimeZone().getID() );
+    assertEquals( CalendarIntervalTrigger.MISFIRE_INSTRUCTION_DO_NOTHING, t.getMisfireInstruction() );
+    assertNotNull( t.getStartTime() );
+  }
+
 }

--- a/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulerUiUtil.java
+++ b/ui/src/main/java/org/pentaho/mantle/client/workspace/SchedulerUiUtil.java
@@ -46,6 +46,7 @@ public class SchedulerUiUtil {
     "logLevel",
     "maximum-query-limit",
     "previousTriggerNow",
+    "QuartzScheduler-LastExecutionTime",
     "query-limit",
     "query-limit-ui-enabled",
     "renderMode",


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7209](https://hv-eng.atlassian.net/browse/SP-7209)
- **Base Case:** [BISERVER-15240](https://hv-eng.atlassian.net/browse/BISERVER-15240) / [BISERVER-15614](https://hv-eng.atlassian.net/browse/BISERVER-15614)
- **Original Master PRs:**
  - [#341](https://github.com/pentaho/pentaho-scheduler-plugin/pull/341) — BISERVER-15528: Fix incorrect timezone in UI for single/run-once jobs
  - [#363](https://github.com/pentaho/pentaho-scheduler-plugin/pull/363) — BISERVER-15240: Fix Last Run field during blockout periods
  - [#369](https://github.com/pentaho/pentaho-scheduler-plugin/pull/369) — Add QuartzScheduler-LastExecutionTime to constants
  - [#372](https://github.com/pentaho/pentaho-scheduler-plugin/pull/372) — BACKLOG-49034: Preserve PAUSED trigger state when saving execution date
  - [#373](https://github.com/pentaho/pentaho-scheduler-plugin/pull/373) — BISERVER-15614: Prevent misfire on resume
  - [#374](https://github.com/pentaho/pentaho-scheduler-plugin/pull/374) — BISERVER-15614: Prevent infinite loop on run-once/end-dated schedule rescheduling

## Changes
- Backports the scheduler Last Run and stability fixes represented by original master PRs #341, #363, #369, #372, #373, and #374.
- Records Last Run from actual job execution time instead of the old trigger-now timestamp path.
- `triggerNow()` no longer persists a trigger-now timestamp before execution.
- Preserves PAUSED trigger state during delete-and-reschedule and avoids immediate misfires after resume.
- Prevents infinite rescheduling loops for run-once or end-dated schedules with no future fire time.
- Keeps the 11.0 maintenance-branch backport aligned with the sibling 10.2 backport; branch-specific conflict handling is captured below.

## Conflict Resolution
- `#363`: `QuartzSchedulerTest.java` conflicted because the 11.0 baseline still carried the older Last Run assertions. Resolved by adopting the newer actual-execution-time test structure.
- `#372`: `QuartzSchedulerTest.java` conflicted due to differing test ordering between branches. Resolved by keeping the branch coverage and relying on `QuartzSchedulerSaveExecutionDateTest` for the save-execution-date path.
- `#373`: `QuartzSchedulerTest.java` conflicted again as the branch still carried the older mock-based save-execution-date tests. Resolved by preserving the maintained 11.0 test coverage while keeping the incoming scheduler behavior.

## Target
- **Target branch:** 11.0
- **Code freeze status:** Informational only — backport targets maintenance branch `11.0` regardless.


[SP-7209]: https://hv-eng.atlassian.net/browse/SP-7209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BISERVER-15240]: https://hv-eng.atlassian.net/browse/BISERVER-15240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BISERVER-15614]: https://hv-eng.atlassian.net/browse/BISERVER-15614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ