### PR TITLE
build[SP-7224]: Bump version of validation-api dependency to 1.1.0.Final

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -71,14 +71,12 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
-            <version>1.0.0.GA</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <classifier>sources</classifier>
-            <version>1.0.0.GA</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- remove repo-local javax.validation:validation-api version ownership
- inherit javax.validation:validation-api 1.1.0.Final from pentaho-parent-pom on 10.2