### PR TITLE
[BISERVER-15590] ORA-12899 value too large for column

### DIFF
--- a/assembly/src/main/quartz/quartz.properties
+++ b/assembly/src/main/quartz/quartz.properties
@@ -187,6 +187,9 @@ org.quartz.threadPool.threadsInheritContextClassLoaderOfInitializingThread = tru
 #         - WebLogicDelegate (for WebLogic drivers)
 #         - OracleDelegate (for Oracle drivers)
 #
+#     Use following delegate for Oracle drivers if you are using ojdbc17.jar or onwards
+#	    org.quartz.jobStore.driverDelegateClass = org.pentaho.platform.scheduler2.quartz.OracleCharBooleanDelegate
+#
 #     org.quartz.jobStore.useProperties = USE_PROPERTIES
 #     org.quartz.jobStore.dataSource = DS_NAME
 #     org.quartz.jobStore.tablePrefix = TABLE_PREFIX

--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/OracleCalendarIntervalTriggerPersistenceDelegate.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/OracleCalendarIntervalTriggerPersistenceDelegate.java
@@ -1,0 +1,62 @@
+/*!
+ * HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
+ *
+ * Copyright 2025 Hitachi Vantara. All rights reserved.
+ *
+ * NOTICE: All information including source code contained herein is, and
+ * remains the sole property of Hitachi Vantara and its licensors. The intellectual
+ * and technical concepts contained herein are proprietary and confidential
+ * to, and are trade secrets of Hitachi Vantara and may be covered by U.S. and foreign
+ * patents, or patents in process, and are protected by trade secret and
+ * copyright laws. The receipt or possession of this source code and/or related
+ * information does not convey or imply any rights to reproduce, disclose or
+ * distribute its contents, or to manufacture, use, or sell anything that it
+ * may describe, in whole or in part. Any reproduction, modification, distribution,
+ * or public display of this information without the express written authorization
+ * from Hitachi Vantara is strictly prohibited and in violation of applicable laws and
+ * international treaties. Access to the source code contained herein is strictly
+ * prohibited to anyone except those individuals and entities who have executed
+ * confidentiality and non-disclosure agreements or other agreements with Hitachi Vantara,
+ * explicitly covering such access.
+ */
+
+package org.pentaho.platform.scheduler2.quartz;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import org.quartz.JobDetail;
+import org.quartz.TriggerKey;
+import org.quartz.impl.jdbcjobstore.CalendarIntervalTriggerPersistenceDelegate;
+import org.quartz.impl.jdbcjobstore.Util;
+import org.quartz.spi.OperableTrigger;
+
+public class OracleCalendarIntervalTriggerPersistenceDelegate extends CalendarIntervalTriggerPersistenceDelegate {
+
+  @Override
+  public int insertExtendedTriggerProperties( Connection conn, OperableTrigger trigger, String state, JobDetail jobDetail )
+    throws SQLException, IOException {
+    return OracleTriggerPersistenceHelper.insertTriggerProperties(
+      conn, trigger, getTriggerProperties( trigger ),
+      Util.rtp( INSERT_SIMPLE_PROPS_TRIGGER, tablePrefix, schedNameLiteral ) );
+  }
+
+  @Override
+  public TriggerPropertyBundle loadExtendedTriggerProperties( Connection conn, TriggerKey triggerKey ) throws SQLException {
+    return OracleTriggerPersistenceHelper.loadTriggerProperties(
+      conn, triggerKey,
+      Util.rtp( SELECT_SIMPLE_PROPS_TRIGGER, tablePrefix, schedNameLiteral ),
+      Util.rtp( SELECT_SIMPLE_TRIGGER, tablePrefix, schedNameLiteral ),
+      this::getTriggerPropertyBundle );
+  }
+
+  @Override
+  public int updateExtendedTriggerProperties( Connection conn, OperableTrigger trigger, String state, JobDetail jobDetail )
+    throws SQLException, IOException {
+    return OracleTriggerPersistenceHelper.updateTriggerProperties(
+      conn, trigger, getTriggerProperties( trigger ),
+      Util.rtp( UPDATE_SIMPLE_PROPS_TRIGGER, tablePrefix, schedNameLiteral ) );
+  }
+
+}

--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/OracleCharBooleanDelegate.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/OracleCharBooleanDelegate.java
@@ -1,0 +1,89 @@
+/*!
+ * HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
+ *
+ * Copyright 2025 Hitachi Vantara. All rights reserved.
+ *
+ * NOTICE: All information including source code contained herein is, and
+ * remains the sole property of Hitachi Vantara and its licensors. The intellectual
+ * and technical concepts contained herein are proprietary and confidential
+ * to, and are trade secrets of Hitachi Vantara and may be covered by U.S. and foreign
+ * patents, or patents in process, and are protected by trade secret and
+ * copyright laws. The receipt or possession of this source code and/or related
+ * information does not convey or imply any rights to reproduce, disclose or
+ * distribute its contents, or to manufacture, use, or sell anything that it
+ * may describe, in whole or in part. Any reproduction, modification, distribution,
+ * or public display of this information without the express written authorization
+ * from Hitachi Vantara is strictly prohibited and in violation of applicable laws and
+ * international treaties. Access to the source code contained herein is strictly
+ * prohibited to anyone except those individuals and entities who have executed
+ * confidentiality and non-disclosure agreements or other agreements with Hitachi Vantara,
+ * explicitly covering such access.
+ */
+
+package org.pentaho.platform.scheduler2.quartz;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Locale;
+
+import org.quartz.impl.jdbcjobstore.CronTriggerPersistenceDelegate;
+import org.quartz.impl.jdbcjobstore.SimpleTriggerPersistenceDelegate;
+import org.quartz.impl.jdbcjobstore.oracle.OracleDelegate;
+
+public class OracleCharBooleanDelegate extends OracleDelegate {
+
+  static final String TRUE_VALUE = "1";
+  static final String FALSE_VALUE = "0";
+
+  @Override
+  protected void setBoolean( PreparedStatement statement, int parameterIndex, boolean value ) throws SQLException {
+    statement.setString( parameterIndex, value ? TRUE_VALUE : FALSE_VALUE );
+  }
+
+  @Override
+  protected boolean getBoolean( ResultSet resultSet, String columnName ) throws SQLException {
+    return readOracleBoolean( resultSet, columnName );
+  }
+
+  /**
+   * Static utility method to read Oracle boolean values from ResultSet.
+   * Supports multiple boolean formats: "1"/"0", "true"/"false", "t"/"f", "y"/"n"
+   * with case-insensitive handling.
+   *
+   * @param resultSet the ResultSet to read from
+   * @param columnName the column name
+   * @return the boolean value
+   * @throws SQLException if a database access error occurs
+   */
+  public static boolean readOracleBoolean( ResultSet resultSet, String columnName ) throws SQLException {
+    String value = resultSet.getString( columnName );
+
+    if ( value == null ) {
+      return false;
+    }
+
+    switch ( value.trim().toLowerCase( Locale.ROOT ) ) {
+      case TRUE_VALUE:
+      case "true":
+      case "t":
+      case "y":
+        return true;
+      case FALSE_VALUE:
+      case "false":
+      case "f":
+      case "n":
+        return false;
+      default:
+        return resultSet.getBoolean( columnName );
+    }
+  }
+
+  @Override
+  protected void addDefaultTriggerPersistenceDelegates() {
+    addTriggerPersistenceDelegate( new SimpleTriggerPersistenceDelegate() );
+    addTriggerPersistenceDelegate( new CronTriggerPersistenceDelegate() );
+    addTriggerPersistenceDelegate( new OracleCalendarIntervalTriggerPersistenceDelegate() );
+    addTriggerPersistenceDelegate( new OracleDailyTimeIntervalTriggerPersistenceDelegate() );
+  }
+}

--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/OracleDailyTimeIntervalTriggerPersistenceDelegate.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/OracleDailyTimeIntervalTriggerPersistenceDelegate.java
@@ -1,0 +1,62 @@
+/*!
+ * HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
+ *
+ * Copyright 2025 Hitachi Vantara. All rights reserved.
+ *
+ * NOTICE: All information including source code contained herein is, and
+ * remains the sole property of Hitachi Vantara and its licensors. The intellectual
+ * and technical concepts contained herein are proprietary and confidential
+ * to, and are trade secrets of Hitachi Vantara and may be covered by U.S. and foreign
+ * patents, or patents in process, and are protected by trade secret and
+ * copyright laws. The receipt or possession of this source code and/or related
+ * information does not convey or imply any rights to reproduce, disclose or
+ * distribute its contents, or to manufacture, use, or sell anything that it
+ * may describe, in whole or in part. Any reproduction, modification, distribution,
+ * or public display of this information without the express written authorization
+ * from Hitachi Vantara is strictly prohibited and in violation of applicable laws and
+ * international treaties. Access to the source code contained herein is strictly
+ * prohibited to anyone except those individuals and entities who have executed
+ * confidentiality and non-disclosure agreements or other agreements with Hitachi Vantara,
+ * explicitly covering such access.
+ */
+
+package org.pentaho.platform.scheduler2.quartz;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import org.quartz.JobDetail;
+import org.quartz.TriggerKey;
+import org.quartz.impl.jdbcjobstore.DailyTimeIntervalTriggerPersistenceDelegate;
+import org.quartz.impl.jdbcjobstore.Util;
+import org.quartz.spi.OperableTrigger;
+
+public class OracleDailyTimeIntervalTriggerPersistenceDelegate extends DailyTimeIntervalTriggerPersistenceDelegate {
+
+  @Override
+  public int insertExtendedTriggerProperties( Connection conn, OperableTrigger trigger, String state, JobDetail jobDetail )
+    throws SQLException, IOException {
+    return OracleTriggerPersistenceHelper.insertTriggerProperties(
+      conn, trigger, getTriggerProperties( trigger ),
+      Util.rtp( INSERT_SIMPLE_PROPS_TRIGGER, tablePrefix, schedNameLiteral ) );
+  }
+
+  @Override
+  public TriggerPropertyBundle loadExtendedTriggerProperties( Connection conn, TriggerKey triggerKey ) throws SQLException {
+    return OracleTriggerPersistenceHelper.loadTriggerProperties(
+      conn, triggerKey,
+      Util.rtp( SELECT_SIMPLE_PROPS_TRIGGER, tablePrefix, schedNameLiteral ),
+      Util.rtp( SELECT_SIMPLE_TRIGGER, tablePrefix, schedNameLiteral ),
+      this::getTriggerPropertyBundle );
+  }
+
+  @Override
+  public int updateExtendedTriggerProperties( Connection conn, OperableTrigger trigger, String state, JobDetail jobDetail )
+    throws SQLException, IOException {
+    return OracleTriggerPersistenceHelper.updateTriggerProperties(
+      conn, trigger, getTriggerProperties( trigger ),
+      Util.rtp( UPDATE_SIMPLE_PROPS_TRIGGER, tablePrefix, schedNameLiteral ) );
+  }
+
+}

--- a/core/src/main/java/org/pentaho/platform/scheduler2/quartz/OracleTriggerPersistenceHelper.java
+++ b/core/src/main/java/org/pentaho/platform/scheduler2/quartz/OracleTriggerPersistenceHelper.java
@@ -1,0 +1,145 @@
+/*!
+ * HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
+ *
+ * Copyright 2025 Hitachi Vantara. All rights reserved.
+ *
+ * NOTICE: All information including source code contained herein is, and
+ * remains the sole property of Hitachi Vantara and its licensors. The intellectual
+ * and technical concepts contained herein are proprietary and confidential
+ * to, and are trade secrets of Hitachi Vantara and may be covered by U.S. and foreign
+ * patents, or patents in process, and are protected by trade secret and
+ * copyright laws. The receipt or possession of this source code and/or related
+ * information does not convey or imply any rights to reproduce, disclose or
+ * distribute its contents, or to manufacture, use, or sell anything that it
+ * may describe, in whole or in part. Any reproduction, modification, distribution,
+ * or public display of this information without the express written authorization
+ * from Hitachi Vantara is strictly prohibited and in violation of applicable laws and
+ * international treaties. Access to the source code contained herein is strictly
+ * prohibited to anyone except those individuals and entities who have executed
+ * confidentiality and non-disclosure agreements or other agreements with Hitachi Vantara,
+ * explicitly covering such access.
+ */
+
+package org.pentaho.platform.scheduler2.quartz;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.function.Function;
+
+import org.quartz.TriggerKey;
+import org.quartz.impl.jdbcjobstore.SimplePropertiesTriggerProperties;
+import org.quartz.impl.jdbcjobstore.TriggerPersistenceDelegate.TriggerPropertyBundle;
+import org.quartz.impl.jdbcjobstore.Util;
+import org.quartz.spi.OperableTrigger;
+
+/**
+ * Shared helper for Oracle-specific trigger persistence operations.
+ * Eliminates duplicate logic between {@link OracleCalendarIntervalTriggerPersistenceDelegate}
+ * and {@link OracleDailyTimeIntervalTriggerPersistenceDelegate}.
+ */
+class OracleTriggerPersistenceHelper {
+
+  private static final String COL_STR_PROP_1 = "STR_PROP_1";
+  private static final String COL_STR_PROP_2 = "STR_PROP_2";
+  private static final String COL_STR_PROP_3 = "STR_PROP_3";
+  private static final String COL_INT_PROP_1 = "INT_PROP_1";
+  private static final String COL_INT_PROP_2 = "INT_PROP_2";
+  private static final String COL_LONG_PROP_1 = "LONG_PROP_1";
+  private static final String COL_LONG_PROP_2 = "LONG_PROP_2";
+  private static final String COL_DEC_PROP_1 = "DEC_PROP_1";
+  private static final String COL_DEC_PROP_2 = "DEC_PROP_2";
+  private static final String COL_BOOL_PROP_1 = "BOOL_PROP_1";
+  private static final String COL_BOOL_PROP_2 = "BOOL_PROP_2";
+
+  private OracleTriggerPersistenceHelper() {
+    // utility class
+  }
+
+  static int insertTriggerProperties( Connection conn, OperableTrigger trigger,
+                                      SimplePropertiesTriggerProperties properties,
+                                      String preparedSql ) throws SQLException {
+    PreparedStatement ps = null;
+    try {
+      ps = conn.prepareStatement( preparedSql );
+      ps.setString( 1, trigger.getKey().getName() );
+      ps.setString( 2, trigger.getKey().getGroup() );
+      ps.setString( 3, properties.getString1() );
+      ps.setString( 4, properties.getString2() );
+      ps.setString( 5, properties.getString3() );
+      ps.setInt( 6, properties.getInt1() );
+      ps.setInt( 7, properties.getInt2() );
+      ps.setLong( 8, properties.getLong1() );
+      ps.setLong( 9, properties.getLong2() );
+      ps.setBigDecimal( 10, properties.getDecimal1() );
+      ps.setBigDecimal( 11, properties.getDecimal2() );
+      ps.setString( 12, properties.isBoolean1() ? OracleCharBooleanDelegate.TRUE_VALUE : OracleCharBooleanDelegate.FALSE_VALUE );
+      ps.setString( 13, properties.isBoolean2() ? OracleCharBooleanDelegate.TRUE_VALUE : OracleCharBooleanDelegate.FALSE_VALUE );
+      return ps.executeUpdate();
+    } finally {
+      Util.closeStatement( ps );
+    }
+  }
+
+  static TriggerPropertyBundle loadTriggerProperties( Connection conn, TriggerKey triggerKey,
+                                                       String selectSql, String errorSql,
+                                                       Function<SimplePropertiesTriggerProperties, TriggerPropertyBundle> bundleFactory )
+    throws SQLException {
+    PreparedStatement ps = null;
+    ResultSet rs = null;
+    try {
+      ps = conn.prepareStatement( selectSql );
+      ps.setString( 1, triggerKey.getName() );
+      ps.setString( 2, triggerKey.getGroup() );
+      rs = ps.executeQuery();
+
+      if ( rs.next() ) {
+        SimplePropertiesTriggerProperties properties = new SimplePropertiesTriggerProperties();
+        properties.setString1( rs.getString( COL_STR_PROP_1 ) );
+        properties.setString2( rs.getString( COL_STR_PROP_2 ) );
+        properties.setString3( rs.getString( COL_STR_PROP_3 ) );
+        properties.setInt1( rs.getInt( COL_INT_PROP_1 ) );
+        properties.setInt2( rs.getInt( COL_INT_PROP_2 ) );
+        properties.setLong1( rs.getLong( COL_LONG_PROP_1 ) );
+        properties.setLong2( rs.getLong( COL_LONG_PROP_2 ) );
+        properties.setDecimal1( rs.getBigDecimal( COL_DEC_PROP_1 ) );
+        properties.setDecimal2( rs.getBigDecimal( COL_DEC_PROP_2 ) );
+        properties.setBoolean1( OracleCharBooleanDelegate.readOracleBoolean( rs, COL_BOOL_PROP_1 ) );
+        properties.setBoolean2( OracleCharBooleanDelegate.readOracleBoolean( rs, COL_BOOL_PROP_2 ) );
+        return bundleFactory.apply( properties );
+      }
+
+      throw new IllegalStateException( "No record found for selection of Trigger with key: '" + triggerKey
+        + "' and statement: " + errorSql );
+    } finally {
+      Util.closeResultSet( rs );
+      Util.closeStatement( ps );
+    }
+  }
+
+  static int updateTriggerProperties( Connection conn, OperableTrigger trigger,
+                                      SimplePropertiesTriggerProperties properties,
+                                      String preparedSql ) throws SQLException {
+    PreparedStatement ps = null;
+    try {
+      ps = conn.prepareStatement( preparedSql );
+      ps.setString( 1, properties.getString1() );
+      ps.setString( 2, properties.getString2() );
+      ps.setString( 3, properties.getString3() );
+      ps.setInt( 4, properties.getInt1() );
+      ps.setInt( 5, properties.getInt2() );
+      ps.setLong( 6, properties.getLong1() );
+      ps.setLong( 7, properties.getLong2() );
+      ps.setBigDecimal( 8, properties.getDecimal1() );
+      ps.setBigDecimal( 9, properties.getDecimal2() );
+      ps.setString( 10, properties.isBoolean1() ? OracleCharBooleanDelegate.TRUE_VALUE : OracleCharBooleanDelegate.FALSE_VALUE );
+      ps.setString( 11, properties.isBoolean2() ? OracleCharBooleanDelegate.TRUE_VALUE : OracleCharBooleanDelegate.FALSE_VALUE );
+      ps.setString( 12, trigger.getKey().getName() );
+      ps.setString( 13, trigger.getKey().getGroup() );
+      return ps.executeUpdate();
+    } finally {
+      Util.closeStatement( ps );
+    }
+  }
+}

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/OracleCalendarIntervalTriggerPersistenceDelegateTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/OracleCalendarIntervalTriggerPersistenceDelegateTest.java
@@ -1,0 +1,255 @@
+/*!
+ * HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
+ *
+ * Copyright 2025 Hitachi Vantara. All rights reserved.
+ *
+ * NOTICE: All information including source code contained herein is, and
+ * remains the sole property of Hitachi Vantara and its licensors. The intellectual
+ * and technical concepts contained herein are proprietary and confidential
+ * to, and are trade secrets of Hitachi Vantara and may be covered by U.S. and foreign
+ * patents, or patents in process, and are protected by trade secret and
+ * copyright laws. The receipt or possession of this source code and/or related
+ * information does not convey or imply any rights to reproduce, disclose or
+ * distribute its contents, or to manufacture, use, or sell anything that it
+ * may describe, in whole or in part. Any reproduction, modification, distribution,
+ * or public display of this information without the express written authorization
+ * from Hitachi Vantara is strictly prohibited and in violation of applicable laws and
+ * international treaties. Access to the source code contained herein is strictly
+ * prohibited to anyone except those individuals and entities who have executed
+ * confidentiality and non-disclosure agreements or other agreements with Hitachi Vantara,
+ * explicitly covering such access.
+ */
+
+package org.pentaho.platform.scheduler2.quartz;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.quartz.CalendarIntervalScheduleBuilder;
+import org.quartz.JobDetail;
+import org.quartz.TriggerKey;
+import org.quartz.impl.jdbcjobstore.SimplePropertiesTriggerProperties;
+import org.quartz.spi.OperableTrigger;
+
+public class OracleCalendarIntervalTriggerPersistenceDelegateTest {
+
+  private TestableOracleCalendarIntervalTriggerPersistenceDelegate delegate;
+  private Connection mockConnection;
+  private PreparedStatement mockPreparedStatement;
+  private ResultSet mockResultSet;
+  private OperableTrigger mockTrigger;
+  private JobDetail mockJobDetail;
+  private TriggerKey triggerKey;
+
+  @Before
+  public void setUp() {
+    delegate = new TestableOracleCalendarIntervalTriggerPersistenceDelegate();
+    mockConnection = mock( Connection.class );
+    mockPreparedStatement = mock( PreparedStatement.class );
+    mockResultSet = mock( ResultSet.class );
+    mockTrigger = mock( OperableTrigger.class );
+    mockJobDetail = mock( JobDetail.class );
+
+    triggerKey = new TriggerKey( "testTrigger", "testGroup" );
+    when( mockTrigger.getKey() ).thenReturn( triggerKey );
+  }
+
+  private SimplePropertiesTriggerProperties createMockProperties() {
+    SimplePropertiesTriggerProperties props = new SimplePropertiesTriggerProperties();
+    props.setString1( "str1" );
+    props.setString2( "str2" );
+    props.setString3( "str3" );
+    props.setInt1( 1 );
+    props.setInt2( 2 );
+    props.setLong1( 100L );
+    props.setLong2( 200L );
+    props.setDecimal1( new BigDecimal( "10.5" ) );
+    props.setDecimal2( new BigDecimal( "20.5" ) );
+    props.setBoolean1( true );
+    props.setBoolean2( false );
+    return props;
+  }
+
+  /**
+   * Test subclass that exposes getTriggerProperties for mocking
+   */
+  private class TestableOracleCalendarIntervalTriggerPersistenceDelegate
+    extends OracleCalendarIntervalTriggerPersistenceDelegate {
+    private SimplePropertiesTriggerProperties mockProperties;
+
+    public void setMockProperties( SimplePropertiesTriggerProperties props ) {
+      this.mockProperties = props;
+    }
+
+    @Override
+    protected SimplePropertiesTriggerProperties getTriggerProperties( OperableTrigger trigger ) {
+      if ( mockProperties != null ) {
+        return mockProperties;
+      }
+      return super.getTriggerProperties( trigger );
+    }
+  }
+
+  @Test
+  public void testInsertExtendedTriggerPropertiesSuccessfully() throws SQLException, IOException {
+    delegate.setMockProperties( createMockProperties() );
+    when( mockConnection.prepareStatement( anyString() ) ).thenReturn( mockPreparedStatement );
+    when( mockPreparedStatement.executeUpdate() ).thenReturn( 1 );
+
+    int result = delegate.insertExtendedTriggerProperties( mockConnection, mockTrigger, "WAITING", mockJobDetail );
+
+    assertEquals( 1, result );
+    verify( mockConnection ).prepareStatement( anyString() );
+    verify( mockPreparedStatement ).setString( 1, "testTrigger" );
+    verify( mockPreparedStatement ).setString( 2, "testGroup" );
+    verify( mockPreparedStatement ).setString( 12, OracleCharBooleanDelegate.TRUE_VALUE );
+    verify( mockPreparedStatement ).setString( 13, OracleCharBooleanDelegate.FALSE_VALUE );
+    verify( mockPreparedStatement ).executeUpdate();
+  }
+
+  @Test
+  public void testInsertExtendedTriggerPropertiesThrowsSQLException() throws SQLException, IOException {
+    delegate.setMockProperties( createMockProperties() );
+    when( mockConnection.prepareStatement( anyString() ) ).thenThrow( new SQLException( "Connection failed" ) );
+
+    try {
+      delegate.insertExtendedTriggerProperties( mockConnection, mockTrigger, "WAITING", mockJobDetail );
+      fail( "Expected SQLException" );
+    } catch ( SQLException e ) {
+      assertEquals( "Connection failed", e.getMessage() );
+    }
+  }
+
+  @Test
+  public void testLoadExtendedTriggerPropertiesNoRecordFound() throws SQLException {
+    when( mockConnection.prepareStatement( anyString() ) ).thenReturn( mockPreparedStatement );
+    when( mockPreparedStatement.executeQuery() ).thenReturn( mockResultSet );
+    when( mockResultSet.next() ).thenReturn( false );
+
+    try {
+      delegate.loadExtendedTriggerProperties( mockConnection, triggerKey );
+      fail( "Expected IllegalStateException" );
+    } catch ( IllegalStateException e ) {
+      assertTrue( e.getMessage().contains( "No record found" ) );
+    }
+  }
+
+  @Test
+  public void testLoadExtendedTriggerPropertiesThrowsSQLException() throws SQLException {
+    when( mockConnection.prepareStatement( anyString() ) ).thenThrow( new SQLException( "Connection failed" ) );
+
+    try {
+      delegate.loadExtendedTriggerProperties( mockConnection, triggerKey );
+      fail( "Expected SQLException" );
+    } catch ( SQLException e ) {
+      assertEquals( "Connection failed", e.getMessage() );
+    }
+  }
+
+  @Test
+  public void testUpdateExtendedTriggerPropertiesSuccessfully() throws SQLException, IOException {
+    delegate.setMockProperties( createMockProperties() );
+    when( mockConnection.prepareStatement( anyString() ) ).thenReturn( mockPreparedStatement );
+    when( mockPreparedStatement.executeUpdate() ).thenReturn( 1 );
+
+    int result = delegate.updateExtendedTriggerProperties( mockConnection, mockTrigger, "WAITING", mockJobDetail );
+
+    assertEquals( 1, result );
+    verify( mockConnection ).prepareStatement( anyString() );
+    verify( mockPreparedStatement ).setString( 10, OracleCharBooleanDelegate.TRUE_VALUE );
+    verify( mockPreparedStatement ).setString( 11, OracleCharBooleanDelegate.FALSE_VALUE );
+    verify( mockPreparedStatement ).setString( 12, "testTrigger" );
+    verify( mockPreparedStatement ).setString( 13, "testGroup" );
+    verify( mockPreparedStatement ).executeUpdate();
+  }
+
+  @Test
+  public void testUpdateExtendedTriggerPropertiesThrowsSQLException() throws SQLException, IOException {
+    delegate.setMockProperties( createMockProperties() );
+    when( mockConnection.prepareStatement( anyString() ) ).thenThrow( new SQLException( "Connection failed" ) );
+
+    try {
+      delegate.updateExtendedTriggerProperties( mockConnection, mockTrigger, "WAITING", mockJobDetail );
+      fail( "Expected SQLException" );
+    } catch ( SQLException e ) {
+      assertEquals( "Connection failed", e.getMessage() );
+    }
+  }
+
+  @Test
+  public void testLoadExtendedTriggerPropertiesSuccessfully() throws SQLException {
+    when( mockConnection.prepareStatement( anyString() ) ).thenReturn( mockPreparedStatement );
+    when( mockPreparedStatement.executeQuery() ).thenReturn( mockResultSet );
+    when( mockResultSet.next() ).thenReturn( true );
+    
+    // Setup mock ResultSet to return distinct values for each property
+    when( mockResultSet.getString( "STR_PROP_1" ) ).thenReturn( "value1" );
+    when( mockResultSet.getString( "STR_PROP_2" ) ).thenReturn( "value2" );
+    when( mockResultSet.getString( "STR_PROP_3" ) ).thenReturn( "value3" );
+    when( mockResultSet.getInt( "INT_PROP_1" ) ).thenReturn( 10 );
+    when( mockResultSet.getInt( "INT_PROP_2" ) ).thenReturn( 20 );
+    when( mockResultSet.getLong( "LONG_PROP_1" ) ).thenReturn( 1000L );
+    when( mockResultSet.getLong( "LONG_PROP_2" ) ).thenReturn( 2000L );
+    when( mockResultSet.getBigDecimal( "DEC_PROP_1" ) ).thenReturn( new BigDecimal( "15.5" ) );
+    when( mockResultSet.getBigDecimal( "DEC_PROP_2" ) ).thenReturn( new BigDecimal( "25.5" ) );
+    when( mockResultSet.getString( "BOOL_PROP_1" ) ).thenReturn( OracleCharBooleanDelegate.TRUE_VALUE );
+    when( mockResultSet.getString( "BOOL_PROP_2" ) ).thenReturn( OracleCharBooleanDelegate.FALSE_VALUE );
+
+    // Create a testable subclass that properly handles the return type
+    TestableLoadOracleCalendarIntervalTriggerPersistenceDelegate testDelegate = 
+      new TestableLoadOracleCalendarIntervalTriggerPersistenceDelegate();
+    Object result = testDelegate.loadExtendedTriggerProperties( mockConnection, triggerKey );
+
+    // Verify the result is not null
+    assertNotNull( result );
+    
+    // Verify PreparedStatement was configured correctly
+    verify( mockConnection ).prepareStatement( anyString() );
+    verify( mockPreparedStatement ).setString( 1, triggerKey.getName() );
+    verify( mockPreparedStatement ).setString( 2, triggerKey.getGroup() );
+    verify( mockPreparedStatement ).executeQuery();
+    
+    // Verify that the captured properties have the expected values
+    assertEquals( "value1", testDelegate.capturedProperties.getString1() );
+    assertEquals( "value2", testDelegate.capturedProperties.getString2() );
+    assertEquals( "value3", testDelegate.capturedProperties.getString3() );
+    assertEquals( 10, testDelegate.capturedProperties.getInt1() );
+    assertEquals( 20, testDelegate.capturedProperties.getInt2() );
+    assertEquals( 1000L, testDelegate.capturedProperties.getLong1() );
+    assertEquals( 2000L, testDelegate.capturedProperties.getLong2() );
+    assertEquals( new BigDecimal( "15.5" ), testDelegate.capturedProperties.getDecimal1() );
+    assertEquals( new BigDecimal( "25.5" ), testDelegate.capturedProperties.getDecimal2() );
+    assertEquals( true, testDelegate.capturedProperties.isBoolean1() );
+    assertEquals( false, testDelegate.capturedProperties.isBoolean2() );
+  }
+
+  /**
+   * Testable subclass for capturing properties during load
+   */
+  private static class TestableLoadOracleCalendarIntervalTriggerPersistenceDelegate
+    extends OracleCalendarIntervalTriggerPersistenceDelegate {
+    public SimplePropertiesTriggerProperties capturedProperties;
+
+    @Override
+    protected TriggerPropertyBundle getTriggerPropertyBundle( SimplePropertiesTriggerProperties properties ) {
+      this.capturedProperties = properties;
+      // Bypass super to avoid enum parsing of mock string values
+      return new TriggerPropertyBundle( CalendarIntervalScheduleBuilder.calendarIntervalSchedule(), null, null );
+    }
+  }
+}

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/OracleCharBooleanDelegateTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/OracleCharBooleanDelegateTest.java
@@ -1,0 +1,177 @@
+/*!
+ * HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
+ *
+ * Copyright 2025 Hitachi Vantara. All rights reserved.
+ *
+ * NOTICE: All information including source code contained herein is, and
+ * remains the sole property of Hitachi Vantara and its licensors. The intellectual
+ * and technical concepts contained herein are proprietary and confidential
+ * to, and are trade secrets of Hitachi Vantara and may be covered by U.S. and foreign
+ * patents, or patents in process, and are protected by trade secret and
+ * copyright laws. The receipt or possession of this source code and/or related
+ * information does not convey or imply any rights to reproduce, disclose or
+ * distribute its contents, or to manufacture, use, or sell anything that it
+ * may describe, in whole or in part. Any reproduction, modification, distribution,
+ * or public display of this information without the express written authorization
+ * from Hitachi Vantara is strictly prohibited and in violation of applicable laws and
+ * international treaties. Access to the source code contained herein is strictly
+ * prohibited to anyone except those individuals and entities who have executed
+ * confidentiality and non-disclosure agreements or other agreements with Hitachi Vantara,
+ * explicitly covering such access.
+ */
+
+package org.pentaho.platform.scheduler2.quartz;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import org.junit.Test;
+
+public class OracleCharBooleanDelegateTest {
+
+  private static final String COLUMN_NAME = "IS_DURABLE";
+
+  private final OracleCharBooleanDelegate delegate = new OracleCharBooleanDelegate();
+
+  @Test
+  public void testSetBooleanWritesSingleCharacterTrue() throws Exception {
+    PreparedStatement statement = mock( PreparedStatement.class );
+
+    delegate.setBoolean( statement, 2, true );
+
+    verify( statement ).setString( 2, OracleCharBooleanDelegate.TRUE_VALUE );
+  }
+
+  @Test
+  public void testSetBooleanWritesSingleCharacterFalse() throws Exception {
+    PreparedStatement statement = mock( PreparedStatement.class );
+
+    delegate.setBoolean( statement, 3, false );
+
+    verify( statement ).setString( 3, OracleCharBooleanDelegate.FALSE_VALUE );
+  }
+
+  @Test
+  public void testGetBooleanSupportsSingleCharacterValues() throws Exception {
+    ResultSet resultSet = mock( ResultSet.class );
+
+    when( resultSet.getString( COLUMN_NAME ) ).thenReturn( "1", "0" );
+
+    assertTrue( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+    assertFalse( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+  }
+
+  @Test
+  public void testGetBooleanSupportsTextValues() throws Exception {
+    ResultSet resultSet = mock( ResultSet.class );
+
+    when( resultSet.getString( COLUMN_NAME ) ).thenReturn( "true", "false", "Y", "N" );
+
+    assertTrue( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+    assertFalse( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+    assertTrue( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+    assertFalse( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+  }
+
+  @Test
+  public void testGetBooleanFallsBackToJdbcParsingForUnexpectedValues() throws Exception {
+    ResultSet resultSet = mock( ResultSet.class );
+
+    when( resultSet.getString( COLUMN_NAME ) ).thenReturn( "unexpected" );
+    when( resultSet.getBoolean( COLUMN_NAME ) ).thenReturn( true );
+
+    assertTrue( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+    verify( resultSet ).getBoolean( COLUMN_NAME );
+  }
+
+  @Test
+  public void testGetBooleanHandlesNullValue() throws Exception {
+    ResultSet resultSet = mock( ResultSet.class );
+
+    when( resultSet.getString( COLUMN_NAME ) ).thenReturn( null );
+
+    assertFalse( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+  }
+
+  @Test
+  public void testGetBooleanHandlesWhitespace() throws Exception {
+    ResultSet resultSet = mock( ResultSet.class );
+
+    when( resultSet.getString( COLUMN_NAME ) ).thenReturn( "  1  ", "  0  ", "  true  ", "  false  " );
+
+    assertTrue( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+    assertFalse( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+    assertTrue( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+    assertFalse( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+  }
+
+  @Test
+  public void testGetBooleanHandlesMixedCase() throws Exception {
+    ResultSet resultSet = mock( ResultSet.class );
+
+    when( resultSet.getString( COLUMN_NAME ) ).thenReturn( "TRUE", "FALSE", "T", "F", "Y", "N" );
+
+    assertTrue( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+    assertFalse( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+    assertTrue( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+    assertFalse( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+    assertTrue( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+    assertFalse( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+  }
+
+  @Test
+  public void testSetBooleanWithVariousParameterIndices() throws Exception {
+    PreparedStatement statement = mock( PreparedStatement.class );
+
+    delegate.setBoolean( statement, 1, true );
+    delegate.setBoolean( statement, 5, false );
+    delegate.setBoolean( statement, 10, true );
+
+    verify( statement ).setString( 1, OracleCharBooleanDelegate.TRUE_VALUE );
+    verify( statement ).setString( 5, OracleCharBooleanDelegate.FALSE_VALUE );
+    verify( statement ).setString( 10, OracleCharBooleanDelegate.TRUE_VALUE );
+  }
+
+  @Test
+  public void testGetBooleanWithLowercaseValues() throws Exception {
+    ResultSet resultSet = mock( ResultSet.class );
+
+    when( resultSet.getString( COLUMN_NAME ) ).thenReturn( "y", "n", "t", "f" );
+
+    assertTrue( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+    assertFalse( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+    assertTrue( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+    assertFalse( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+  }
+
+  @Test
+  public void testGetBooleanWithEmptyString() throws Exception {
+    ResultSet resultSet = mock( ResultSet.class );
+
+    when( resultSet.getString( COLUMN_NAME ) ).thenReturn( "" );
+    when( resultSet.getBoolean( COLUMN_NAME ) ).thenReturn( false );
+
+    assertFalse( delegate.getBoolean( resultSet, COLUMN_NAME ) );
+  }
+
+  @Test
+  public void testSetBooleanMultipleValues() throws Exception {
+    PreparedStatement statement = mock( PreparedStatement.class );
+
+    delegate.setBoolean( statement, 1, true );
+    delegate.setBoolean( statement, 2, true );
+    delegate.setBoolean( statement, 3, false );
+    delegate.setBoolean( statement, 4, false );
+
+    verify( statement ).setString( 1, OracleCharBooleanDelegate.TRUE_VALUE );
+    verify( statement ).setString( 2, OracleCharBooleanDelegate.TRUE_VALUE );
+    verify( statement ).setString( 3, OracleCharBooleanDelegate.FALSE_VALUE );
+    verify( statement ).setString( 4, OracleCharBooleanDelegate.FALSE_VALUE );
+  }
+}

--- a/core/src/test/java/org/pentaho/platform/scheduler2/quartz/OracleDailyTimeIntervalTriggerPersistenceDelegateTest.java
+++ b/core/src/test/java/org/pentaho/platform/scheduler2/quartz/OracleDailyTimeIntervalTriggerPersistenceDelegateTest.java
@@ -1,0 +1,255 @@
+/*!
+ * HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
+ *
+ * Copyright 2025 Hitachi Vantara. All rights reserved.
+ *
+ * NOTICE: All information including source code contained herein is, and
+ * remains the sole property of Hitachi Vantara and its licensors. The intellectual
+ * and technical concepts contained herein are proprietary and confidential
+ * to, and are trade secrets of Hitachi Vantara and may be covered by U.S. and foreign
+ * patents, or patents in process, and are protected by trade secret and
+ * copyright laws. The receipt or possession of this source code and/or related
+ * information does not convey or imply any rights to reproduce, disclose or
+ * distribute its contents, or to manufacture, use, or sell anything that it
+ * may describe, in whole or in part. Any reproduction, modification, distribution,
+ * or public display of this information without the express written authorization
+ * from Hitachi Vantara is strictly prohibited and in violation of applicable laws and
+ * international treaties. Access to the source code contained herein is strictly
+ * prohibited to anyone except those individuals and entities who have executed
+ * confidentiality and non-disclosure agreements or other agreements with Hitachi Vantara,
+ * explicitly covering such access.
+ */
+
+package org.pentaho.platform.scheduler2.quartz;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.quartz.DailyTimeIntervalScheduleBuilder;
+import org.quartz.JobDetail;
+import org.quartz.TriggerKey;
+import org.quartz.impl.jdbcjobstore.SimplePropertiesTriggerProperties;
+import org.quartz.spi.OperableTrigger;
+
+public class OracleDailyTimeIntervalTriggerPersistenceDelegateTest {
+
+  private TestableOracleDailyTimeIntervalTriggerPersistenceDelegate delegate;
+  private Connection mockConnection;
+  private PreparedStatement mockPreparedStatement;
+  private ResultSet mockResultSet;
+  private OperableTrigger mockTrigger;
+  private JobDetail mockJobDetail;
+  private TriggerKey triggerKey;
+
+  @Before
+  public void setUp() {
+    delegate = new TestableOracleDailyTimeIntervalTriggerPersistenceDelegate();
+    mockConnection = mock( Connection.class );
+    mockPreparedStatement = mock( PreparedStatement.class );
+    mockResultSet = mock( ResultSet.class );
+    mockTrigger = mock( OperableTrigger.class );
+    mockJobDetail = mock( JobDetail.class );
+
+    triggerKey = new TriggerKey( "dailyTrigger", "dailyGroup" );
+    when( mockTrigger.getKey() ).thenReturn( triggerKey );
+  }
+
+  private SimplePropertiesTriggerProperties createMockProperties() {
+    SimplePropertiesTriggerProperties props = new SimplePropertiesTriggerProperties();
+    props.setString1( "str1" );
+    props.setString2( "str2" );
+    props.setString3( "str3" );
+    props.setInt1( 1 );
+    props.setInt2( 2 );
+    props.setLong1( 100L );
+    props.setLong2( 200L );
+    props.setDecimal1( new BigDecimal( "10.5" ) );
+    props.setDecimal2( new BigDecimal( "20.5" ) );
+    props.setBoolean1( true );
+    props.setBoolean2( false );
+    return props;
+  }
+
+  /**
+   * Test subclass that exposes getTriggerProperties for mocking
+   */
+  private class TestableOracleDailyTimeIntervalTriggerPersistenceDelegate
+    extends OracleDailyTimeIntervalTriggerPersistenceDelegate {
+    private SimplePropertiesTriggerProperties mockProperties;
+
+    public void setMockProperties( SimplePropertiesTriggerProperties props ) {
+      this.mockProperties = props;
+    }
+
+    @Override
+    protected SimplePropertiesTriggerProperties getTriggerProperties( OperableTrigger trigger ) {
+      if ( mockProperties != null ) {
+        return mockProperties;
+      }
+      return super.getTriggerProperties( trigger );
+    }
+  }
+
+  @Test
+  public void testInsertExtendedTriggerPropertiesSuccessfully() throws SQLException, IOException {
+    delegate.setMockProperties( createMockProperties() );
+    when( mockConnection.prepareStatement( anyString() ) ).thenReturn( mockPreparedStatement );
+    when( mockPreparedStatement.executeUpdate() ).thenReturn( 1 );
+
+    int result = delegate.insertExtendedTriggerProperties( mockConnection, mockTrigger, "WAITING", mockJobDetail );
+
+    assertEquals( 1, result );
+    verify( mockConnection ).prepareStatement( anyString() );
+    verify( mockPreparedStatement ).setString( 1, "dailyTrigger" );
+    verify( mockPreparedStatement ).setString( 2, "dailyGroup" );
+    verify( mockPreparedStatement ).setString( 12, OracleCharBooleanDelegate.TRUE_VALUE );
+    verify( mockPreparedStatement ).setString( 13, OracleCharBooleanDelegate.FALSE_VALUE );
+    verify( mockPreparedStatement ).executeUpdate();
+  }
+
+  @Test
+  public void testInsertExtendedTriggerPropertiesThrowsSQLException() throws SQLException, IOException {
+    delegate.setMockProperties( createMockProperties() );
+    when( mockConnection.prepareStatement( anyString() ) ).thenThrow( new SQLException( "Connection failed" ) );
+
+    try {
+      delegate.insertExtendedTriggerProperties( mockConnection, mockTrigger, "WAITING", mockJobDetail );
+      fail( "Expected SQLException" );
+    } catch ( SQLException e ) {
+      assertEquals( "Connection failed", e.getMessage() );
+    }
+  }
+
+  @Test
+  public void testLoadExtendedTriggerPropertiesNoRecordFound() throws SQLException {
+    when( mockConnection.prepareStatement( anyString() ) ).thenReturn( mockPreparedStatement );
+    when( mockPreparedStatement.executeQuery() ).thenReturn( mockResultSet );
+    when( mockResultSet.next() ).thenReturn( false );
+
+    try {
+      delegate.loadExtendedTriggerProperties( mockConnection, triggerKey );
+      fail( "Expected IllegalStateException" );
+    } catch ( IllegalStateException e ) {
+      assertTrue( e.getMessage().contains( "No record found" ) );
+    }
+  }
+
+  @Test
+  public void testLoadExtendedTriggerPropertiesThrowsSQLException() throws SQLException {
+    when( mockConnection.prepareStatement( anyString() ) ).thenThrow( new SQLException( "Connection failed" ) );
+
+    try {
+      delegate.loadExtendedTriggerProperties( mockConnection, triggerKey );
+      fail( "Expected SQLException" );
+    } catch ( SQLException e ) {
+      assertEquals( "Connection failed", e.getMessage() );
+    }
+  }
+
+  @Test
+  public void testUpdateExtendedTriggerPropertiesSuccessfully() throws SQLException, IOException {
+    delegate.setMockProperties( createMockProperties() );
+    when( mockConnection.prepareStatement( anyString() ) ).thenReturn( mockPreparedStatement );
+    when( mockPreparedStatement.executeUpdate() ).thenReturn( 1 );
+
+    int result = delegate.updateExtendedTriggerProperties( mockConnection, mockTrigger, "PAUSED", mockJobDetail );
+
+    assertEquals( 1, result );
+    verify( mockConnection ).prepareStatement( anyString() );
+    verify( mockPreparedStatement ).setString( 10, OracleCharBooleanDelegate.TRUE_VALUE );
+    verify( mockPreparedStatement ).setString( 11, OracleCharBooleanDelegate.FALSE_VALUE );
+    verify( mockPreparedStatement ).setString( 12, "dailyTrigger" );
+    verify( mockPreparedStatement ).setString( 13, "dailyGroup" );
+    verify( mockPreparedStatement ).executeUpdate();
+  }
+
+  @Test
+  public void testUpdateExtendedTriggerPropertiesThrowsSQLException() throws SQLException, IOException {
+    delegate.setMockProperties( createMockProperties() );
+    when( mockConnection.prepareStatement( anyString() ) ).thenThrow( new SQLException( "Connection failed" ) );
+
+    try {
+      delegate.updateExtendedTriggerProperties( mockConnection, mockTrigger, "WAITING", mockJobDetail );
+      fail( "Expected SQLException" );
+    } catch ( SQLException e ) {
+      assertEquals( "Connection failed", e.getMessage() );
+    }
+  }
+
+  @Test
+  public void testLoadExtendedTriggerPropertiesSuccessfully() throws SQLException {
+    when( mockConnection.prepareStatement( anyString() ) ).thenReturn( mockPreparedStatement );
+    when( mockPreparedStatement.executeQuery() ).thenReturn( mockResultSet );
+    when( mockResultSet.next() ).thenReturn( true );
+    
+    // Setup mock ResultSet to return distinct values for each property
+    when( mockResultSet.getString( "STR_PROP_1" ) ).thenReturn( "value1" );
+    when( mockResultSet.getString( "STR_PROP_2" ) ).thenReturn( "value2" );
+    when( mockResultSet.getString( "STR_PROP_3" ) ).thenReturn( "value3" );
+    when( mockResultSet.getInt( "INT_PROP_1" ) ).thenReturn( 10 );
+    when( mockResultSet.getInt( "INT_PROP_2" ) ).thenReturn( 20 );
+    when( mockResultSet.getLong( "LONG_PROP_1" ) ).thenReturn( 1000L );
+    when( mockResultSet.getLong( "LONG_PROP_2" ) ).thenReturn( 2000L );
+    when( mockResultSet.getBigDecimal( "DEC_PROP_1" ) ).thenReturn( new BigDecimal( "15.5" ) );
+    when( mockResultSet.getBigDecimal( "DEC_PROP_2" ) ).thenReturn( new BigDecimal( "25.5" ) );
+    when( mockResultSet.getString( "BOOL_PROP_1" ) ).thenReturn( OracleCharBooleanDelegate.TRUE_VALUE );
+    when( mockResultSet.getString( "BOOL_PROP_2" ) ).thenReturn( OracleCharBooleanDelegate.FALSE_VALUE );
+
+    // Create a testable subclass that properly handles the return type
+    TestableLoadOracleDailyTimeIntervalTriggerPersistenceDelegate testDelegate = 
+      new TestableLoadOracleDailyTimeIntervalTriggerPersistenceDelegate();
+    Object result = testDelegate.loadExtendedTriggerProperties( mockConnection, triggerKey );
+
+    // Verify the result is not null
+    assertNotNull( result );
+    
+    // Verify PreparedStatement was configured correctly
+    verify( mockConnection ).prepareStatement( anyString() );
+    verify( mockPreparedStatement ).setString( 1, triggerKey.getName() );
+    verify( mockPreparedStatement ).setString( 2, triggerKey.getGroup() );
+    verify( mockPreparedStatement ).executeQuery();
+    
+    // Verify that the captured properties have the expected values
+    assertEquals( "value1", testDelegate.capturedProperties.getString1() );
+    assertEquals( "value2", testDelegate.capturedProperties.getString2() );
+    assertEquals( "value3", testDelegate.capturedProperties.getString3() );
+    assertEquals( 10, testDelegate.capturedProperties.getInt1() );
+    assertEquals( 20, testDelegate.capturedProperties.getInt2() );
+    assertEquals( 1000L, testDelegate.capturedProperties.getLong1() );
+    assertEquals( 2000L, testDelegate.capturedProperties.getLong2() );
+    assertEquals( new BigDecimal( "15.5" ), testDelegate.capturedProperties.getDecimal1() );
+    assertEquals( new BigDecimal( "25.5" ), testDelegate.capturedProperties.getDecimal2() );
+    assertEquals( true, testDelegate.capturedProperties.isBoolean1() );
+    assertEquals( false, testDelegate.capturedProperties.isBoolean2() );
+  }
+
+  /**
+   * Testable subclass for capturing properties during load
+   */
+  private static class TestableLoadOracleDailyTimeIntervalTriggerPersistenceDelegate
+    extends OracleDailyTimeIntervalTriggerPersistenceDelegate {
+    public SimplePropertiesTriggerProperties capturedProperties;
+
+    @Override
+    protected TriggerPropertyBundle getTriggerPropertyBundle( SimplePropertiesTriggerProperties properties ) {
+      this.capturedProperties = properties;
+      // Bypass super to avoid enum parsing of mock string values
+      return new TriggerPropertyBundle( DailyTimeIntervalScheduleBuilder.dailyTimeIntervalSchedule(), null, null );
+    }
+  }
+}


### PR DESCRIPTION
Added new delegate for Oracle drivers if you are using ojdbc17.jar or onwards
- org.quartz.jobStore.driverDelegateClass = org.pentaho.platform.scheduler2.quartz.OracleCharBooleanDelegate